### PR TITLE
Registration Matrix

### DIFF
--- a/src/models/models.stack.js
+++ b/src/models/models.stack.js
@@ -56,7 +56,6 @@ export default class ModelsStack extends ModelsBase {
 
     // TRANSFORMATION MATRICES
     this._regMatrix = new THREE.Matrix4();
-	this._regMatrix.identity();
 	
     this._ijk2LPS = null;
     this._lps2IJK = null;

--- a/src/models/models.stack.js
+++ b/src/models/models.stack.js
@@ -55,7 +55,9 @@ export default class ModelsStack extends ModelsBase {
     this._minMax = [65535, -32768];
 
     // TRANSFORMATION MATRICES
-
+    this._regMatrix = new THREE.Matrix4();
+	this._regMatrix.identity();
+	
     this._ijk2LPS = null;
     this._lps2IJK = null;
 
@@ -388,7 +390,7 @@ export default class ModelsStack extends ModelsBase {
       this._xCosine.y * this._spacing.x, this._yCosine.y * this._spacing.y, this._zCosine.y * this._spacing.z, this._origin.y,
       this._xCosine.z * this._spacing.x, this._yCosine.z * this._spacing.y, this._zCosine.z * this._spacing.z, this._origin.z,
       0, 0, 0, 1);
-
+    this._ijk2LPS.premultiply(this._regMatrix);
     this._lps2IJK = new THREE.Matrix4();
     this._lps2IJK.getInverse(this._ijk2LPS);
   }
@@ -762,6 +764,14 @@ return a.sopInstanceUID - b.sopInstanceUID;
 
   get halfDimensionsIJK() {
     return this._halfDimensionsIJK;
+  }
+  
+  set regMatrix(regMatrix) {
+	  this._regMatrix = regMatrix;
+  }
+  
+  get regMatrix() {
+	  return this._regMatrix;
   }
 
   set ijk2LPS(ijk2LPS) {


### PR DESCRIPTION
This branch is to apply a registration matrix to a Volume.

Something like this:


>           var series = seriesContainer[0].mergeSeries(seriesContainer);
>           var stack = series[0].stack[0];
>           console.log(stack);
>           let aux= new THREE.Matrix4();
>           aux.set(
>           -0.999545, -0.023569, 0.018786, 44.958416,
>           0.022023, -0.996659, -0.078650, -2.742024,
>           0.020577, -0.078200, 0.996725, -179.169698,
>           0.000000, 0.000000, 0.000000, 1.000000);
>           stack._regMatrix=aux;

This is a example:

Before:
![before](https://cloud.githubusercontent.com/assets/8203181/23415608/5fac8704-fda5-11e6-8fb7-8f853d9f0b2a.png)

After:
![after](https://cloud.githubusercontent.com/assets/8203181/23415619/63f1dff8-fda5-11e6-844f-796b673845b1.png)

However, there is something that I dont know if is a issue for someone (box is not axis parallel):
![after2](https://cloud.githubusercontent.com/assets/8203181/23415634/7225e646-fda5-11e6-9ec3-0ffbdfe769e8.png)
