### PR TITLE
replace ../../src/*** to ../*** and transform es6 code to es5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,10 @@
 {
   "presets": ["es2015"],
-  "ignore": ["external/**/*"]
+  "ignore": ["external/**/*"],
+
+  "env": {
+    "cjs": {
+      "plugins": ["add-module-exports"]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ deprecated
 dist
 node_modules
 old_data
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 node_modules
 old_data
 .vscode
+.jsbeautifyrc

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .sass-cache
 .tmp
 .idea
+lib
 bower_components
 deprecated
 dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,12 @@
-old_data
+.DS_STORE
+.publish
+.sass-cache
+.tmp
+.idea
+bower_components
+deprecated
+dist
 node_modules
+old_data
+.vscode
+.jsbeautifyrc

--- a/package.json
+++ b/package.json
@@ -1,23 +1,38 @@
 {
   "name": "ami.js",
   "version": "0.0.16-dev",
-  "main": "src/ami.js",
-  "keywords": ["ami", "ami.js","three.js", "webgl", "dicom", "nifti", "awesome", "medical", "imaging", "xtk", "nrrd", "vtk", "stl", "trk"],
+  "main": "lib/ami.js",
+  "keywords": [
+    "ami",
+    "ami.js",
+    "three.js",
+    "webgl",
+    "dicom",
+    "nifti",
+    "awesome",
+    "medical",
+    "imaging",
+    "xtk",
+    "nrrd",
+    "vtk",
+    "stl",
+    "trk"
+  ],
   "author": {
-    "name" : "Nicolas Rannou",
-    "email" : "nicolas@eunate.ch",
-    "url" : "https://eunate.ch"
+    "name": "Nicolas Rannou",
+    "email": "nicolas@eunate.ch",
+    "url": "https://eunate.ch"
   },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://fnndsc.github.io/ami"
   },
-  "config" : { 
+  "config": {
     "threeVersion": "r83",
     "amiCDN": "https://cdnjs.cloudflare.com/ajax/libs/ami.js/",
     "gaKey": "UA-39303022-3",
-    "transforms" : "-t [babelify --presets [ es2015 ] ]"
+    "transforms": "-t [babelify --presets [ es2015 ] ]"
   },
   "dependencies": {
     "dicom-parser": "1.7.3",
@@ -27,7 +42,7 @@
     "nrrd-js": "^0.2.1",
     "nifti-reader-js": "v0.5.3",
     "pako": "1.0.1"
-    },
+  },
   "scripts": {
     "dist:prepare": "node ./scripts/$npm_package_config_mode.js --dist",
     "dist:watchAmi": "watchify -d src/ami $npm_package_config_transforms --standalone AMI -o dist/build/ami.js -v",
@@ -40,6 +55,7 @@
     "build:examples": "npm run dist:prepare --ami.js:mode=examples && find examples -name '*.js' -print0 | xargs -0 -n1 -I{} bash -c \"echo Building {}; browserify {} -d -v $npm_package_config_transforms > dist/{} \"",
     "build:ami": "browserify src/ami.js -d -v $npm_package_config_transforms --standalone AMI > build/ami.js && uglifyjs build/ami.js -o build/ami.min.js",
     "build": "npm run clean && cp index.html dist/index.html && npm run build:examples && npm run doc",
+    "build-cjs": "rimraf lib && cross-env BABEL_ENV=cjs babel ./src -d lib",
     "clean": "rm -rf dist/*",
     "test": "karma start",
     "doc": "jsdoc -p -r -R README.md -c jsdoc.conf -d dist/doc src",
@@ -47,26 +63,29 @@
     "deploy": "npm run build && gh-pages -d dist"
   },
   "devDependencies": {
-    "browserify": "^13.1.0",
-    "uglify-js": "^2.7.3",
-    "live-server": "^1.1.0",
     "babel-cli": "latest",
-    "shelljs": "latest",
-    "gh-pages": "latest",
-    "eslint": "latest",
-    "eslint-config-google": "latest",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.13.2",
     "babelify": "7.3.0",
+    "browserify": "^13.1.0",
+    "cross-env": "^3.2.3",
+    "eslint": "latest",
+    "eslint-config-google": "latest",
+    "gh-pages": "latest",
     "glslify": "5.1.0",
+    "jasmine-core": "latest",
     "jsdoc": "jsdoc3/jsdoc#master",
     "karma": "latest",
-    "phantomjs": "latest",
     "karma-browserify": "latest",
     "karma-jasmine": "latest",
     "karma-phantomjs-launcher": "latest",
     "karma-spec-reporter": "latest",
-    "jasmine-core": "latest",
+    "live-server": "^1.1.0",
+    "phantomjs": "latest",
+    "rimraf": "^2.6.1",
+    "shelljs": "latest",
+    "uglify-js": "^2.7.3",
     "watchify": "3.7.0"
   },
   "engines": {

--- a/scripts/examples.js
+++ b/scripts/examples.js
@@ -21,14 +21,14 @@ const ExampleTemplate = require('./templates/examples.js');
 //
 try {
   fs.statSync(destRootDir);
-} catch(e) {
+} catch (e) {
   fs.mkdirSync(destRootDir);
 }
 
 // <dev> or <dist> or <> / lessons
 try {
   fs.statSync(destDir);
-} catch(e) {
+} catch (e) {
   fs.mkdirSync(destDir);
 }
 
@@ -49,7 +49,7 @@ fs.readdir(targetDir, function(e, files) {
     // <dev> or <dist> or <> / lessons / <lessonName>
     try {
       fs.statSync(lessonDestDir);
-    } catch(e) {
+    } catch (e) {
       fs.mkdirSync(lessonDestDir);
     }
 

--- a/scripts/lessons.js
+++ b/scripts/lessons.js
@@ -12,7 +12,7 @@ let _mode = 'dist';
 let _destRootDir = 'dist';
 let _destFile = 'index.html';
 
-if(process.argv[2] === '--demo') {
+if (process.argv[2] === '--demo') {
   // inplace replace demo.thml
   _mode = 'demo';
   _destRootDir = '';
@@ -27,10 +27,10 @@ const mode = _mode;
 const LessonTemplate = require('./templates/lessons.js');
 
 //
-if(_destRootDir!=='') {
+if (_destRootDir!=='') {
   try {
     fs.statSync(destRootDir);
-  } catch(e) {
+  } catch (e) {
     fs.mkdirSync(destRootDir);
   }
 }
@@ -38,7 +38,7 @@ if(_destRootDir!=='') {
 // <dev> or <dist> or <> / lessons
 try {
   fs.statSync(destDir);
-} catch(e) {
+} catch (e) {
   fs.mkdirSync(destDir);
 }
 
@@ -60,12 +60,12 @@ fs.readdir(targetDir, function(e, files) {
     // <dev> or <dist> or <> / lessons / <lessonName>
     try {
       fs.statSync(lessonDestDir);
-    } catch(e) {
+    } catch (e) {
       fs.mkdirSync(lessonDestDir);
     }
 
     // if dev, generate proper index.html in proper location
-    if(mode !== 'demo') {
+    if (mode !== 'demo') {
       // copy static files to right location
       toCopy.forEach(function(file) {
         let targetFile = path.join(lessonTargetDir, file);

--- a/scripts/router.js
+++ b/scripts/router.js
@@ -1,6 +1,6 @@
 require('shelljs/global');
 
-if(process.argv[2] && process.argv[3]) {
+if (process.argv[2] && process.argv[3]) {
   const mode = process.argv[2];
   const target = process.argv[3];
   const file = (mode === 'lessons') ? 'demo.js' : `${target}.js`;
@@ -8,12 +8,12 @@ if(process.argv[2] && process.argv[3]) {
 
   let buildAmi = '';
   // also watch AMI if lessons mode
-  if(mode === 'lessons') {
+  if (mode === 'lessons') {
     buildAmi = 'npm run dist:watchAmi';
   }
 
   exec(`npm run dist --ami.js:mode=${mode} --ami.js:target=${directory}/${file} --ami.js:open=${directory}/ & ${buildAmi}`);
-}else{
+} else {
   console.warn('router.js requires 2 arguments. Make sure the following arguments are correct:');
   process.argv.forEach(function(val, index, array) {
     console.warn(index + ': ' + val);

--- a/src/geometries/geometries.slice.js
+++ b/src/geometries/geometries.slice.js
@@ -1,5 +1,5 @@
 /** * Imports ***/
-import coreIntersections from '../../src/core/core.intersections';
+import coreIntersections from '../core/core.intersections';
 
 /**
  *

--- a/src/helpers/helpers.localizer.js
+++ b/src/helpers/helpers.localizer.js
@@ -1,10 +1,10 @@
 /** * Imports ***/
 import ShadersUniform from
-  '../../src/shaders/shaders.localizer.uniform';
+  '../shaders/shaders.localizer.uniform';
 import ShadersVertex from
-  '../../src/shaders/shaders.localizer.vertex';
+  '../shaders/shaders.localizer.vertex';
 import ShadersFragment from
-  '../../src/shaders/shaders.localizer.fragment';
+  '../shaders/shaders.localizer.fragment';
 
 /**
  * @module helpers/localizer

--- a/src/helpers/helpers.slice.js
+++ b/src/helpers/helpers.slice.js
@@ -1,10 +1,10 @@
 /** * Imports ***/
-import GeometriesSlice from '../../src/geometries/geometries.slice';
-import ShadersUniform from '../../src/shaders/shaders.data.uniform';
-import ShadersVertex from '../../src/shaders/shaders.data.vertex';
-import ShadersFragment from '../../src/shaders/shaders.data.fragment';
+import GeometriesSlice from '../geometries/geometries.slice';
+import ShadersUniform from '../shaders/shaders.data.uniform';
+import ShadersVertex from '../shaders/shaders.data.vertex';
+import ShadersFragment from '../shaders/shaders.data.fragment';
 
-import HelpersMaterialMixin from '../../src/helpers/helpers.material.mixin';
+import HelpersMaterialMixin from '../helpers/helpers.material.mixin';
 
 /**
  * @module helpers/slice

--- a/src/helpers/helpers.stack.js
+++ b/src/helpers/helpers.stack.js
@@ -1,7 +1,7 @@
 /** * Imports ***/
-import HelpersBorder from '../../src/helpers/helpers.border';
-import HelpersBoundingBox from '../../src/helpers/helpers.boundingbox';
-import HelpersSlice from '../../src/helpers/helpers.slice';
+import HelpersBorder from '../helpers/helpers.border';
+import HelpersBoundingBox from '../helpers/helpers.boundingbox';
+import HelpersSlice from '../helpers/helpers.slice';
 
 /**
  * Helper to easily display and interact with a stack.<br>

--- a/src/helpers/helpers.volumerendering.js
+++ b/src/helpers/helpers.volumerendering.js
@@ -1,9 +1,9 @@
 /** * Imports ***/
-import ShadersUniform from '../../src/shaders/shaders.vr.uniform';
-import ShadersVertex from '../../src/shaders/shaders.vr.vertex';
-import ShadersFragment from '../../src/shaders/shaders.vr.fragment';
+import ShadersUniform from '../shaders/shaders.vr.uniform';
+import ShadersVertex from '../shaders/shaders.vr.vertex';
+import ShadersFragment from '../shaders/shaders.vr.fragment';
 
-import HelpersMaterialMixin from '../../src/helpers/helpers.material.mixin';
+import HelpersMaterialMixin from '../helpers/helpers.material.mixin';
 
 
 /**

--- a/src/helpers/helpers.voxel.js
+++ b/src/helpers/helpers.voxel.js
@@ -1,6 +1,6 @@
-import GeometriesVoxel from '../../src/geometries/geometries.voxel';
-import ModelsStack from '../../src/models/models.stack';
-import ModelsVoxel from '../../src/models/models.voxel';
+import GeometriesVoxel from '../geometries/geometries.voxel';
+import ModelsStack from '../models/models.stack';
+import ModelsVoxel from '../models/models.voxel';
 
 /**
  * @module helpers/voxel

--- a/src/loaders/loaders.base.js
+++ b/src/loaders/loaders.base.js
@@ -1,5 +1,5 @@
 /** Imports **/
-import HelpersProgressBar from '../../src/helpers/helpers.progressbar';
+import HelpersProgressBar from '../helpers/helpers.progressbar';
 
 /**
  *

--- a/src/loaders/loaders.volume.js
+++ b/src/loaders/loaders.volume.js
@@ -3,12 +3,12 @@ const PAKO = require('pako');
 const URL = require('url');
 
 import LoadersBase from './loaders.base';
-import ModelsSeries from '../../src/models/models.series';
-import ModelsStack from '../../src/models/models.stack';
-import ModelsFrame from '../../src/models/models.frame';
-import ParsersDicom from '../../src/parsers/parsers.dicom';
-import ParsersNifti from '../../src/parsers/parsers.nifti';
-import ParsersNrrd from '../../src/parsers/parsers.nrrd';
+import ModelsSeries from '../models/models.series';
+import ModelsStack from '../models/models.stack';
+import ModelsFrame from '../models/models.frame';
+import ParsersDicom from '../parsers/parsers.dicom';
+import ParsersNifti from '../parsers/parsers.nifti';
+import ParsersNrrd from '../parsers/parsers.nrrd';
 
 
 /**

--- a/src/models/models.frame.js
+++ b/src/models/models.frame.js
@@ -1,5 +1,5 @@
 /** * Imports ***/
-import ModelsBase from '../../src/models/models.base';
+import ModelsBase from '../models/models.base';
 
 /**
  * Frame object.

--- a/src/models/models.series.js
+++ b/src/models/models.series.js
@@ -1,5 +1,5 @@
 /** * Imports ***/
-import ModelsBase from '../../src/models/models.base';
+import ModelsBase from '../models/models.base';
 
 /**
  * Series object.

--- a/src/models/models.stack.js
+++ b/src/models/models.stack.js
@@ -1,7 +1,7 @@
 /** * Imports ***/
-import CoreColors from '../../src/core/core.colors';
-import CoreUtils from '../../src/core/core.utils';
-import ModelsBase from '../../src/models/models.base';
+import CoreColors from '../core/core.colors';
+import CoreUtils from '../core/core.utils';
+import ModelsBase from '../models/models.base';
 
 let binaryString = require('math-float32-to-binary-string');
 

--- a/src/widgets/widgets.handle.js
+++ b/src/widgets/widgets.handle.js
@@ -1,5 +1,5 @@
-import WidgetsBase from '../../src/widgets/widgets.base';
-import CoreIntersections from '../../src/core/core.intersections';
+import WidgetsBase from '../widgets/widgets.base';
+import CoreIntersections from '../core/core.intersections';
 
 
 /**

--- a/src/widgets/widgets.ruler.js
+++ b/src/widgets/widgets.ruler.js
@@ -1,5 +1,5 @@
-import WidgetsBase from '../../src/widgets/widgets.base';
-import WidgetsHandle from '../../src/widgets/widgets.handle';
+import WidgetsBase from '../widgets/widgets.base';
+import WidgetsHandle from '../widgets/widgets.handle';
 
 /**
  * @module widgets/handle

--- a/src/widgets/widgets.voxelProbe.js
+++ b/src/widgets/widgets.voxelProbe.js
@@ -1,5 +1,5 @@
 /** * Imports ***/
-import HelpersVoxel from '../../src/helpers/helpers.voxel';
+import HelpersVoxel from '../helpers/helpers.voxel';
 
 /**
  * @module widgets/voxelProbe


### PR DESCRIPTION
#108 

1. replace `../../src/***` to `../***` only at `src/` path 
2. fix some eslint error.
3. transform es6 code to commonjs

**==note==**

before run `npm publish`, run `npm run build-cjs`. the npm package enterpoint now is `lib/ami.js`.

already run test successfully.