### PR TITLE
Widgets review: handling of container offsets, simplified VoxelProbe

### DIFF
--- a/src/helpers/helpers.voxel.js
+++ b/src/helpers/helpers.voxel.js
@@ -157,8 +157,8 @@ export default class HelpersVoxel extends THREE.Object3D {
 
     // update div position
     let selectedElement = document.getElementById('VJSWidgetVoxelProbe' + this.id);
-    selectedElement.style.top = this._voxel.screenCoordinates.y;
-    selectedElement.style.left = this._voxel.screenCoordinates.x;
+    selectedElement.style.top = this._voxel.screenCoordinates.y + 'px';
+    selectedElement.style.left = this._voxel.screenCoordinates.x + 'px';
     // window.console.log(this._voxel);
     // selectedElement.style['transform-origin'] = 'top left';
     // selectedElement.style['transform'] = 'translate(' + this._voxel.screenCoordinates.x + 'px, ' + this._voxel.screenCoordinates.y + 'px)';

--- a/src/widgets/widgets.base.js
+++ b/src/widgets/widgets.base.js
@@ -3,7 +3,7 @@
  */
 export default class WidgetsBase extends THREE.Object3D {
 
-  constructor() {
+  constructor(container) {
     // init THREE Object 3D
     super();
 
@@ -26,11 +26,51 @@ export default class WidgetsBase extends THREE.Object3D {
     this._dragged = false;
     // can not call it visible because it conflicts with THREE.Object3D
     this._displayed = true;
+
+    this._container = container;
+
+  }
+
+  initOffsets() {
+    var box = this._container.getBoundingClientRect();
+
+    var body = document.body;
+    var docEl = document.documentElement;
+
+    var scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
+    var scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
+
+    var clientTop = docEl.clientTop || body.clientTop || 0;
+    var clientLeft = docEl.clientLeft || body.clientLeft || 0;
+
+    var top  = box.top +  scrollTop - clientTop;
+    var left = box.left + scrollLeft - clientLeft;
+
+    this._offsets = { top: Math.round(top), left: Math.round(left) };
+  }
+
+  offsetChanged() {
+    this.initOffsets();
+    this.update();
+  }
+
+  getMouseOffsets(event, container) {
+
+    return {
+      x: (event.clientX - this._offsets.left) / container.offsetWidth * 2 - 1,
+      y: -((event.clientY - this._offsets.top) / container.offsetHeight) * 2 + 1,
+      screenX: event.clientX - this._offsets.left,
+      screenY: event.clientY - this._offsets.top
+    };
   }
 
   update() {
     // to be overloaded
   	window.console.log('update() should be overloaded!');
+  }
+
+  free() {
+    this._container = null;
   }
 
   updateColor() {

--- a/src/widgets/widgets.handle.js
+++ b/src/widgets/widgets.handle.js
@@ -10,12 +10,11 @@ import CoreIntersections from '../core/core.intersections';
 export default class WidgetsHandle extends WidgetsBase {
 
   constructor(targetMesh, controls, camera, container) {
-    super();
+    super(container);
 
     this._targetMesh = targetMesh;
     this._controls = controls;
     this._camera = camera;
-    this._container = container;
 
     // if no target mesh, use plane for FREE dragging.
     this._plane = {
@@ -59,6 +58,8 @@ export default class WidgetsHandle extends WidgetsBase {
     // create handle
     this.create();
 
+    this.initOffsets();
+
     // event listeners
     this.onMove = this.onMove.bind(this);
     this.onHover = this.onHover.bind(this);
@@ -88,6 +89,10 @@ export default class WidgetsHandle extends WidgetsBase {
 
   onStart(evt) {
     evt.preventDefault();
+
+    var offsets = this.getMouseOffsets(evt, this._container);
+
+    this._mouse.set(offsets.x, offsets.y);
 
     // update raycaster
     this._raycaster.setFromCamera(this._mouse, this._camera);
@@ -142,8 +147,8 @@ export default class WidgetsHandle extends WidgetsBase {
   onMove(evt) {
     evt.preventDefault();
 
-    this._mouse.set((event.clientX / this._container.offsetWidth) * 2 - 1,
-                    -(event.clientY / this._container.offsetHeight) * 2 + 1);
+    var offsets = this.getMouseOffsets(evt, this._container);
+    this._mouse.set(offsets.x, offsets.y);
 
     // update screen position of handle
     this._screenPosition = this.worldToScreen(this._worldPosition, this._camera, this._container);
@@ -311,9 +316,11 @@ export default class WidgetsHandle extends WidgetsBase {
     // threejs stuff
 
     // dom
-
+    this._container.removeChild(this._dom);
     // event
     this.removeEventListeners();
+
+	super.free();
   }
 
   set worldPosition(worldPosition) {

--- a/src/widgets/widgets.ruler.js
+++ b/src/widgets/widgets.ruler.js
@@ -9,12 +9,11 @@ import WidgetsHandle from '../widgets/widgets.handle';
 export default class WidgetsRuler extends WidgetsBase {
 
   constructor(targetMesh, controls, camera, container) {
-    super();
+    super(container);
 
     this._targetMesh = targetMesh;
     this._controls = controls;
     this._camera = camera;
-    this._container = container;
 
     this._active = true;
 
@@ -56,6 +55,8 @@ export default class WidgetsRuler extends WidgetsBase {
     // Create ruler
     this.create();
 
+    this.initOffsets();
+
     this.onMove = this.onMove.bind(this);
     this.addEventListeners();
   }
@@ -89,7 +90,7 @@ export default class WidgetsRuler extends WidgetsBase {
     // First Handle
     this._handles[0].onEnd(evt);
 
-    window.console.log(this);
+    // window.console.log(this);
 
     // Second Handle
     if(this._dragged || !this._handles[1].tracking) {
@@ -215,6 +216,36 @@ export default class WidgetsRuler extends WidgetsBase {
   updateDOMColor() {
     this._line.style.backgroundColor = `${this._color}`;
     this._distance.style.borderColor = `${this._color}`;
+  }
+
+  offsetChanged() {
+
+	//Trick to allow recalc screenPosition and update the handles
+	//I guess there's a better way of doing this...
+    this._handles[0].worldPosition = this._handles[0].worldPosition;
+    this._handles[1].worldPosition = this._handles[1].worldPosition;
+
+    this.initOffsets();
+    this.update();
+  }
+
+  free() {
+
+    this._container.removeEventListener('mousewheel', this.onMove);
+    this._container.removeEventListener('DOMMouseScroll', this.onMove);
+
+    this._handles.forEach((h) => {
+      h.free();
+    });
+
+    this._handles = [];
+
+    this._container.removeChild(this._line);
+    this._container.removeChild(this._distance);
+
+    this.remove(this._mesh);
+
+    super.free();
   }
 
   get worldPosition() {


### PR DESCRIPTION
Here's my patches...
Basically:
- `WidgetsBase` now has two new methods: `initOffsets` and `offsetChanged`. The first is called in the constructor of all widgets (actually it could be invoked directly in the WIdgetsBase constructor) to precalculate the container offsets and simplify mouse position calculations. The second one must be called when the container position changes: in the base form it recalculates the container offsets and calls `update`. Since these methods all work on a `_container` instance, I modified the WidgetsBase constructor to take the container as a parameter. Finally I added the `free` method, that in it's base form releases the container. Extending classes should implement logic to release used resources (eventhandlers, dom elements, ...).

- `WidgetsRuler` and `WidgetsHandle`: implemented needed parent methods

- `WidgetsVoxelProbe`: this is the class that changed the most... I made it extend `WidgetsBase` and overridden some methods. I (hope I) simplified the code as you suggested: now the widget uses only one `HelpersVoxel`. If more than one is needed it should be instantiated at the application level.

I hope I didn't mess up too much the code... :-)
