### PR TITLE
Make able to select Roi and Biruler widgets in widget_example. Change…

### DIFF
--- a/examples/widget_handle/widget_handle.js
+++ b/examples/widget_handle/widget_handle.js
@@ -6,6 +6,8 @@ import WidgetsHandle from '../../src/widgets/widgets.handle';
 import WidgetsRuler from '../../src/widgets/widgets.ruler';
 import WidgetsVoxelProbe from '../../src/widgets/widgets.voxelProbe';
 import WidgetsAnnotation from '../../src/widgets/widgets.annotation';
+import WidgetsRoiWidget from '../../src/widgets/widgets.roi';
+import WidgetsBiruler from '../../src/widgets/widgets.biruler';
 import ControlsTrackball from '../../src/controls/controls.trackball';
 
 // standard global variables
@@ -22,6 +24,8 @@ const widgetsAvailable = [
   'Ruler',
   'VoxelProbe',
   'Annotation',
+  'RoiWidget',
+  'Biruler'
 ];
 const guiObjects = {
   type: 'Handle',
@@ -165,6 +169,16 @@ window.onload = function() {
         case 'Annotation':
           widget =
             new WidgetsAnnotation(stackHelper.slice.mesh, controls, camera, threeD);
+          widget.worldPosition = intersects[0].point;
+          break;
+        case 'RoiWidget':
+          widget =
+            new WidgetsRoiWidget(stackHelper.slice.mesh, controls, camera, threeD);
+          widget.worldPosition = intersects[0].point;
+          break;
+        case 'Biruler':
+          widget =
+            new WidgetsBiruler(stackHelper.slice.mesh, controls, camera, threeD);
           widget.worldPosition = intersects[0].point;
           break;
         default:

--- a/src/widgets/widgets.biruler.js
+++ b/src/widgets/widgets.biruler.js
@@ -337,7 +337,7 @@ export default class WidgetsBiRuler extends WidgetsBase {
         transform += ` rotate(${angle}deg)`;
 
         this._line.style.transform = transform;
-        this._line.style.width = length;
+        this._line.style.width = length + 'px';
 
         // update distance
         let w0 = this._handles[0].worldPosition;
@@ -378,7 +378,7 @@ export default class WidgetsBiRuler extends WidgetsBase {
         transform += ` rotate(${angle}deg)`;
 
         this._line2.style.transform = transform;
-        this._line2.style.width = length;
+        this._line2.style.width = length + 'px';
 
         // update distance
         let w02 = this._handles[2].worldPosition;
@@ -415,7 +415,7 @@ export default class WidgetsBiRuler extends WidgetsBase {
         transform += ` rotate(${angle}deg)`;
 
         this._dashline.style.transform = transform;
-        this._dashline.style.width = length;
+        this._dashline.style.width = length + 'px';
     }
 
     updateDOMColor() {

--- a/src/widgets/widgets.ruler.js
+++ b/src/widgets/widgets.ruler.js
@@ -270,7 +270,7 @@ export default class WidgetsRuler extends WidgetsBase {
     transform += ` rotate(${angle}deg)`;
 
     this._line.style.transform = transform;
-    this._line.style.width = length;
+    this._line.style.width = length + 'px';
 
     // update distance
     let w0 = this._handles[0].worldPosition;


### PR DESCRIPTION
Make able to select Roi and Biruler widgets in widget_example. (For now the widgets are in development but I think its useful to be able to use them)
Change units of line width to 'px' instead of none. (Line width defined without 'px' units are not visible in Polymer for some reason)