### PR TITLE
alpha correction for sampling rate

### DIFF
--- a/src/shaders/shaders.vr.fragment.js
+++ b/src/shaders/shaders.vr.fragment.js
@@ -106,7 +106,7 @@ void main(void) {
       colorSample.r = colorSample.g = colorSample.b = intensity * alphaSample;
     }
 
-    alphaSample = alphaSample * uAlphaCorrection;
+    alphaSample = 1.0 - pow((1.0- alphaSample),tStep*uAlphaCorrection);
     alphaSample *= (1.0 - accumulatedAlpha);
 
     accumulatedColor += alphaSample * colorSample;


### PR DESCRIPTION
Hi,

this is a small adjustment for the alpha sampling formula based on http://developer.download.nvidia.com/books/HTML/gpugems/gpugems_ch39.html (see equation 3)
This will correct the amount of alpha blending so the perceived transparency is same  under different sampling rates. This is especially noticeable in the vr_singlepass  example where the sampling rate changes when you rotate the volume.

I suspect that uAlphaCorrection was there to manually change this? I still left this in the formula so in the vr_singlepass example you still can do some correction if the build in LUT's do not have the transparency you want.

Best regards,
Pjotr