### PR TITLE
Progress bar improvment

### DIFF
--- a/src/helpers/helpers.progressbar.js
+++ b/src/helpers/helpers.progressbar.js
@@ -22,6 +22,7 @@ export default class HelpersProgressBar {
     this._mode = null;
     this._value = null;
     this._total = null;
+    this._totalFiles = null;
 
     this.init();
   }
@@ -54,7 +55,8 @@ export default class HelpersProgressBar {
     this.updateUI();
   }
 
-  update(value, total, mode) {
+  // url can be used in child class to show overall progress bar
+  update(value, total, mode, url = '') {
     this._mode = mode;
     this._value = value;
     // depending on CDN, total return to XHTTPRequest can be 0.
@@ -127,5 +129,13 @@ export default class HelpersProgressBar {
     bar.style.width = '0%';
 
     return bar;
+  }
+
+  set totalFiles(totalFiles) {
+      this._totalFiles = totalFiles;
+  }
+
+  get totalFiles() {
+      return this._totalFiles;
   }
 }

--- a/src/loaders/loaders.base.js
+++ b/src/loaders/loaders.base.js
@@ -259,6 +259,7 @@ export default class LoadersBase extends EventEmitter {
 
     if (this._progressBar) {
       this._progressBar.totalFiles = url.length;
+      this._progressBar.cancellationToken = token;
     }
 
     // emit 'load-start' event

--- a/src/loaders/loaders.base.js
+++ b/src/loaders/loaders.base.js
@@ -259,7 +259,7 @@ export default class LoadersBase extends EventEmitter {
 
     if (this._progressBar) {
       this._progressBar.totalFiles = url.length;
-      this._progressBar.cancellationToken = token;
+      this._progressBar.requests = requests;
     }
 
     // emit 'load-start' event

--- a/src/loaders/loaders.base.js
+++ b/src/loaders/loaders.base.js
@@ -91,8 +91,7 @@ export default class LoadersBase extends EventEmitter {
 
           // will be removed after eventer set up
           if (this._progressBar) {
-            this._progressBar.update(this._loaded, this._totalLoaded,
-              'load');
+            this._progressBar.update(this._loaded, this._totalLoaded, 'load', url);
           }
 
           let buffer = request.response;
@@ -156,8 +155,7 @@ export default class LoadersBase extends EventEmitter {
         });
         // will be removed after eventer set up
         if (this._progressBar) {
-          this._progressBar.update(this._loaded, this._totalLoaded,
-            'load');
+          this._progressBar.update(this._loaded, this._totalLoaded, 'load', url);
         }
       };
 
@@ -257,6 +255,10 @@ export default class LoadersBase extends EventEmitter {
     // if we load a single file, convert it to an array
     if (!Array.isArray(url)) {
       url = [url];
+    }
+
+    if (this._progressBar) {
+      this._progressBar.totalFiles = url.length;
     }
 
     // emit 'load-start' event

--- a/src/loaders/loaders.volume.js
+++ b/src/loaders/loaders.volume.js
@@ -58,7 +58,7 @@ export default class LoadersVolumes extends LoadersBase {
     // after the rendering will be blocked with intensive JS
     // will be removed after eventer set up
     if (this._progressBar) {
-      this._progressBar.update(0, 100, 'parse');
+      this._progressBar.update(0, 100, 'parse', response.url);
     }
 
     return new Promise(
@@ -242,7 +242,7 @@ export default class LoadersVolumes extends LoadersBase {
 
     // will be removed after eventer set up
     if (this._progressBar) {
-      this._progressBar.update(this._parsed, this._totalParsed, 'parse');
+      this._progressBar.update(this._parsed, this._totalParsed, 'parse', url);
     }
 
     // emit 'parsing' event


### PR DESCRIPTION
This additions allow to create nice overall progress bar.

Example of HelpersProgressBar.update override:
```
function (value, total, mode, url) {
    const modeProgress = total === 0 ? 0.5 : (0.5 * value / total); // total can be 0 (XHTTPRequest)
    let addValue = 0;
    if (this.filesProgress.hasOwnProperty(url)) {
        addValue -= this.filesProgress[url] / this.totalFiles;
    }
    this.filesProgress[url] = mode === 'load' ? modeProgress : 0.5 + modeProgress;
    addValue += this.filesProgress[url] / this.totalFiles;
    if (addValue > 0) {
        this.overallProgress += addValue;
        this.updateProgress(this.overallProgress, Math.round(this.overallProgress * 100) + ' %');
    }
}
```

Also requests Map is passed to progress bar, because Cancel button is usually placed near progress bar