### PR TITLE
Fix _windowWidth typo in helpers.slice.js

### DIFF
--- a/src/helpers/helpers.slice.js
+++ b/src/helpers/helpers.slice.js
@@ -350,7 +350,7 @@ export default class HelpersSlice extends HelpersMaterialMixin(THREE.Object3D) {
         this._windowCenter = this._stack.windowCenter;
       }
 
-      if (this.__windowWidth === null) {
+      if (this._windowWidth === null) {
         this._windowWidth = this._stack.windowWidth;
       }
 


### PR DESCRIPTION
'this.__windowWidth' has a redundant underscore.