### PR TITLE
Fix event.totalFiles undefined bug in HelpersProgressBarEventBased

### DIFF
--- a/src/helpers/helpers.progressbar.eventbased.js
+++ b/src/helpers/helpers.progressbar.eventbased.js
@@ -43,7 +43,7 @@ export default class HelpersProgressBarEventBased {
     const self = this;
 
     this._emitter.on('load-start', function(event) {
-      const totalFiles = event.totalFiles;
+      const totalFiles = event.files.length;
       self.totalFile = totalFiles;
       self._domTotalFile.innerHTML = totalFiles;
     });


### PR DESCRIPTION
`'load-start'` event object doesn't have `totalFiles` property.
https://github.com/FNNDSC/ami/blob/bdeada54a75308418975499568e843eaf271091b/src/loaders/loaders.base.js#L267-L270
This makes `self.totalFile` undefined, and causes `#total-file` and `#current-progress` components don't work properly.
Replacing `event.totalFiles` with `event.files.length` could solve this bug. 