### PR TITLE
Mhd pixetype

### DIFF
--- a/src/parsers/parsers.mhd.js
+++ b/src/parsers/parsers.mhd.js
@@ -75,6 +75,8 @@ export default class ParsersMHD extends ParsersVolume {
   }
 
   pixelType(frameIndex = 0) {
+    // 0 - int
+    // 1 - float
     let type = 0;
     if (this._header.ElementType === 'MET_UFLOAT' ||
         this._header.ElementType === 'MET_FLOAT') {

--- a/src/parsers/parsers.mhd.js
+++ b/src/parsers/parsers.mhd.js
@@ -75,9 +75,12 @@ export default class ParsersMHD extends ParsersVolume {
   }
 
   pixelType(frameIndex = 0) {
-    // 0 - int
-    // 1 - float
-    return 0;
+    let type = 0;
+    if (this._header.ElementType === 'MET_UFLOAT' ||
+        this._header.ElementType === 'MET_FLOAT') {
+      type = 1;
+    }
+    return type;
   }
 
   bitsAllocated(frameIndex = 0) {


### PR DESCRIPTION
Fix for the issue : https://github.com/FNNDSC/ami/issues/291

 - added a check before setting pixeltype = 0 or 1 (instead of always 0).