### PR TITLE
Point at unbroken jp2 module

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "dicom-parser": "1.7.3",
-        "image-JPEG2000": "OHIF/image-JPEG2000#master",
+        "image-JPEG2000": "ReflexionMed/image-JPEG2000#master",
         "jpeg-lossless-decoder-js": "1.2.3",
         "math-float32-to-binary-string": "^1.0.0",
         "nifti-reader-js": "v0.5.3",


### PR DESCRIPTION
This points at a different repo w/o the pdf.js foolishness via submodule.  I think @ReflexionMed started this branch to fix things.  

Fixes:
- https://github.com/FNNDSC/ami/issues/208

Thanks.