### PR TITLE
Fixed recursive call in Loader

### DIFF
--- a/src/loaders/loaders.volume.js
+++ b/src/loaders/loaders.volume.js
@@ -172,7 +172,7 @@ export default class LoadersVolumes extends LoadersBase {
               // recursive call for each frame
               // better than for loop to be able
               // to update dom with "progress" callback
-              setTimeout(
+              setTimeout(() ->
                 this.parseFrame(
                   series, stack, response.url, 0,
                   volumeParser, resolve, reject), 0);
@@ -261,7 +261,7 @@ export default class LoadersVolumes extends LoadersBase {
 
       resolve(series);
     } else {
-      setTimeout(
+      setTimeout(() -> 
         this.parseFrame(
           series, stack, url, this._parsed, dataParser, resolve, reject), 0
       );

--- a/src/loaders/loaders.volume.js
+++ b/src/loaders/loaders.volume.js
@@ -261,7 +261,7 @@ export default class LoadersVolumes extends LoadersBase {
 
       resolve(series);
     } else {
-      setTimeout(() => 
+      setTimeout(() =>
         this.parseFrame(
           series, stack, url, this._parsed, dataParser, resolve, reject), 0
       );

--- a/src/loaders/loaders.volume.js
+++ b/src/loaders/loaders.volume.js
@@ -172,7 +172,7 @@ export default class LoadersVolumes extends LoadersBase {
               // recursive call for each frame
               // better than for loop to be able
               // to update dom with "progress" callback
-              setTimeout(() ->
+              setTimeout(() =>
                 this.parseFrame(
                   series, stack, response.url, 0,
                   volumeParser, resolve, reject), 0);
@@ -261,7 +261,7 @@ export default class LoadersVolumes extends LoadersBase {
 
       resolve(series);
     } else {
-      setTimeout(() -> 
+      setTimeout(() => 
         this.parseFrame(
           series, stack, url, this._parsed, dataParser, resolve, reject), 0
       );

--- a/src/loaders/loaders.volume.js
+++ b/src/loaders/loaders.volume.js
@@ -32,7 +32,7 @@ import ParsersNrrd from '../parsers/parsers.nrrd';
  *   // Function when resource is loaded
  *   function(object) {
  *     //scene.add( object );
- *     window.console.log(object);
+ *     console.log(object);
  *   }
  * );
  */
@@ -62,7 +62,7 @@ export default class LoadersVolumes extends LoadersBase {
 
     return new Promise(
       (resolve, reject) => {
-        window.setTimeout(
+        setTimeout(
           () => {
             resolve(new Promise((resolve, reject) => {
               let data = response;
@@ -109,7 +109,7 @@ export default class LoadersVolumes extends LoadersBase {
               try {
                 volumeParser = new Parser(data, 0);
               } catch (e) {
-                window.console.log(e);
+                console.log(e);
                 // emit 'parse-error' event
                 this.emit('parse-error', {
                   file: response.url,
@@ -294,7 +294,7 @@ export default class LoadersVolumes extends LoadersBase {
         Parser = ParsersNrrd;
         break;
       default:
-        window.console.log('unsupported extension: ' + extension);
+        console.log('unsupported extension: ' + extension);
         return false;
     }
     return Parser;


### PR DESCRIPTION
`setTimeOut` requires you to pass a function. `parseFrame` does not return a function. It (apparently) returns something string-like. That's also a constructor for `setTimeOut` but then one that runs `eval` on the string. Nobody wants that, and that's also the reason modern browsers block it. I think the intended behavior was to call `setTimeOut` with a function, so `parseFrame` is called after a timeout and recursively calls itself. 

I didn't know how to test the code, so I'll leave that up to you