### PR TITLE
Mixed numberOfChannels

### DIFF
--- a/src/models/models.series.js
+++ b/src/models/models.series.js
@@ -27,7 +27,6 @@ export default class ModelsSeries extends ModelsBase {
     // it is used in the loader in case a dicom/nifti contains multiple frames
     // should be updated after merge or renamed
     this._numberOfFrames = 0;
-    this._numberOfChannels = 1;
 
     // patient information
     this._patientID = '';
@@ -51,7 +50,6 @@ export default class ModelsSeries extends ModelsBase {
    *   - mergeSeries method
    *   - _seriesInstanceUID
    *   - _numberOfFrames
-   *   - _numberOfChannels
    *   _ _stack
    *
    * @param {ModelsSeries} model - Model to be validated as series.
@@ -65,7 +63,6 @@ export default class ModelsSeries extends ModelsBase {
       typeof model.mergeSeries === 'function' &&
       model.hasOwnProperty('_seriesInstanceUID') &&
       model.hasOwnProperty('_numberOfFrames') &&
-      model.hasOwnProperty('_numberOfChannels') &&
       model.hasOwnProperty('_stack') &&
       typeof model._stack !== 'undefined' &&
       Array === model._stack.constructor)) {
@@ -370,24 +367,6 @@ export default class ModelsSeries extends ModelsBase {
    */
   get numberOfFrames() {
     return this._numberOfFrames;
-  }
-
-  /**
-   * Number of channels setter
-   *
-   * @param {*} numberOfChannels
-   */
-  set numberOfChannels(numberOfChannels) {
-    this._numberOfChannels = numberOfChannels;
-  }
-
-  /**
-   * Number of channels getter
-   *
-   * @return {*}
-   */
-  get numberOfChannels() {
-    return this._numberOfChannels;
   }
 
   /**

--- a/src/models/models.stack.js
+++ b/src/models/models.stack.js
@@ -251,8 +251,9 @@ export default class ModelsStack extends ModelsBase {
     this._rescaleSlope = middleFrame.rescaleSlope || 1;
     this._rescaleIntercept = middleFrame.rescaleIntercept || 0;
 
+    this.computeByAllFrames();
+
     // rescale/slope min max
-    this.computeMinMaxIntensities();
     this._minMax[0] = CoreUtils.rescaleSlopeIntercept(
       this._minMax[0],
       this._rescaleSlope,
@@ -404,23 +405,25 @@ export default class ModelsStack extends ModelsBase {
   }
 
   /**
-   * Find min and max intensities among all frames.
+   * Find min and max intensities and max numberOfChannels among all frames.
    */
-  computeMinMaxIntensities() {
-    // what about colors!!!!?
-    // we ignore values if NaNs
-    // https://github.com/FNNDSC/ami/issues/185
+  computeByAllFrames() {
     for (let i = 0; i < this._frame.length; i++) {
       // get min/max
       let min = this._frame[i].minMax[0];
+      let max = this._frame[i].minMax[1];
+      // what about colors!!!!?
+      // we ignore values if NaNs
+      // https://github.com/FNNDSC/ami/issues/185
       if (!Number.isNaN(min)) {
         this._minMax[0] = Math.min(this._minMax[0], min);
       }
-
-      let max = this._frame[i].minMax[1];
       if (!Number.isNaN(max)) {
         this._minMax[1] = Math.max(this._minMax[1], max);
       }
+
+      // get max numberOfChannels (for correct packing)
+      this._numberOfChannels = Math.max(this._numberOfChannels, this._frame[i].numberOfChannels);
     }
   }
 
@@ -642,12 +645,14 @@ export default class ModelsStack extends ModelsBase {
         frameIndex = ~~(i / frameDimension);
         inFrameIndex = i % (frameDimension);
 
-        data[3 * packIndex] =
-          frame[frameIndex].pixelData[3 * inFrameIndex];
-        data[3 * packIndex + 1] =
-          frame[frameIndex].pixelData[3 * inFrameIndex + 1];
-        data[3 * packIndex + 2] =
-          frame[frameIndex].pixelData[3 * inFrameIndex + 2];
+        if (frame[frameIndex].numberOfChannels === 3) {
+          data[3 * packIndex] = frame[frameIndex].pixelData[3 * inFrameIndex];
+          data[3 * packIndex + 1] = frame[frameIndex].pixelData[3 * inFrameIndex + 1];
+          data[3 * packIndex + 2] = frame[frameIndex].pixelData[3 * inFrameIndex + 2];
+        } else {
+          data[3 * packIndex] = data[3 * packIndex + 1] = data[3 * packIndex + 2] =
+            frame[frameIndex].pixelData[inFrameIndex];
+        }
         packIndex++;
       }
 

--- a/src/parsers/parsers.dicom.js
+++ b/src/parsers/parsers.dicom.js
@@ -739,6 +739,10 @@ let frameTime;
   }
 
   _decodePixelData(frameIndex = 0) {
+    if (!this._dataSet.elements.x7fe00010) { // common for SR modality
+      return [];
+    }
+
     // if compressed..?
     let transferSyntaxUID = this.transferSyntaxUID();
 


### PR DESCRIPTION
- empty pixelData case is corrected (SR modality)
- _numberOfChannels is removed from model.series (isn't used, stacks may have different values in one series)
- stack._numberOfChannels is equal to max frame._numberOfChannels (computed in stack.prepare())
- packTo8Bits() is corrected for stack._numberOfChannels === 3