### PR TITLE
Use WebWorkers to improve loading performance

### DIFF
--- a/examples/loader_dicoms/loader_dicoms.js
+++ b/examples/loader_dicoms/loader_dicoms.js
@@ -1,9 +1,9 @@
 /* globals Stats*/
 
-import ControlsTrackball from 'base/controls/controls.trackball';
-import HelpersStack from 'base/helpers/helpers.stack';
-import LoadersVolume from 'base/loaders/loaders.volume';
-
+import ControlsTrackball from 'examplesBase/controls/controls.trackball';
+import HelpersStack from 'examplesBase/helpers/helpers.stack';
+import LoadersVolumeWorker from 'examplesBase/loaders/loaders2';
+import LoadersVolume from 'examplesBase/loaders/loaders.volume';
 // standard global variables
 let controls;
 let renderer;
@@ -76,106 +76,168 @@ window.onload = function() {
 
   // instantiate the loader
   // it loads and parses the dicom image
-  let loader = new LoadersVolume(threeD);
+  // let loader = new LoadersVolume(threeD);
 
   let t2 = [
     '36444280',
     '36444294',
     '36444308',
-    // '36444322',
-    // '36444336',
-    // '36444350',
-    // '36444364',
-    // '36444378',
-    // '36444392',
-    // '36444406',
-    // '36748256',
-    // '36444434',
-    // '36444448',
-    // '36444462',
-    // '36444476',
-    // '36444490',
-    // '36444504',
-    // '36444518',
-    // '36444532',
-    // '36746856',
-    // '36746870',
-    // '36746884',
-    // '36746898',
-    // '36746912',
-    // '36746926',
-    // '36746940',
-    // '36746954',
-    // '36746968',
-    // '36746982',
-    // '36746996',
-    // '36747010',
-    // '36747024',
-    // '36748200',
-    // '36748214',
-    // '36748228',
-    // '36748270',
-    // '36748284',
-    // '36748298',
-    // '36748312',
-    // '36748326',
-    // '36748340',
-    // '36748354',
-    // '36748368',
-    // '36748382',
-    // '36748396',
-    // '36748410',
-    // '36748424',
-    // '36748438',
-    // '36748452',
-    // '36748466',
-    // '36748480',
-    // '36748494',
-    // '36748508',
-    // '36748522',
-    // '36748242',
+    '36444322',
+    '36444336',
+    '36444350',
+    '36444364',
+    '36444378',
+    '36444392',
+    '36444406',
+    '36748256',
+    '36444434',
+    '36444448',
+    '36444462',
+    '36444476',
+    '36444490',
+    '36444504',
+    '36444518',
+    '36444532',
+    '36746856',
+    '36746870',
+    '36746884',
+    '36746898',
+    '36746912',
+    '36746926',
+    '36746940',
+    '36746954',
+    '36746968',
+    '36746982',
+    '36746996',
+    '36747010',
+    '36747024',
+    '36748200',
+    '36748214',
+    '36748228',
+    '36748270',
+    '36748284',
+    '36748298',
+    '36748312',
+    '36748326',
+    '36748340',
+    '36748354',
+    '36748368',
+    '36748382',
+    '36748396',
+    '36748410',
+    '36748424',
+    '36748438',
+    '36748452',
+    '36748466',
+    '36748480',
+    '36748494',
+    '36748508',
+    '36748522',
+    '36748242',
   ];
 
-  let files = t2.map(function(v) {
+  let files = [...t2, ...t2, ...t2].map(function(v) {
     return 'https://cdn.rawgit.com/FNNDSC/data/master/dicom/adi_brain/' + v;
   });
 
-  // load sequence for all files
-  loader
-    .load(files)
-    .then(function() {
+  let mgzFiles = ['https://cdn.jsdelivr.net/gh/fnndsc/data/mgh/orig.mgz'];
+
+  console.time('someFunction');
+
+
+
+  // do some benchmarking
+
+
+  // // // load sequence for all files
+  // let loaderYeah = new LoadersVolume(threeD);
+  // loaderYeah
+  //   .load(files)
+  //   .then(function() {
+  //     console.timeEnd('someFunction');
+
+   
+  //   });
+
+  // // load sequence for all files
+  // return;
+
+  // pool of size 4 ?
+  // re-use
+  const w0 = new LoadersVolumeWorker();
+  const w1 = new LoadersVolumeWorker();
+  const w2 = new LoadersVolumeWorker();
+  const w3 = new LoadersVolumeWorker();
+
+  const fileTodo = files;
+
+  const handleWorkerFinished = (worker) => {
+    if (fileTodo.length > 0) {
+      parallelProgress.push(
+        worker.loadInstance({file: fileTodo.pop()}).then((value) => {
+        handleWorkerFinished(worker);
+        return value;
+      }));
+    }
+  }
+
+  const parallelProgress = [];
+  parallelProgress.push(w0.loadInstance({file: fileTodo.pop()}).then((value) => {
+    handleWorkerFinished(w0);
+    return value;
+  }));
+  parallelProgress.push(w1.loadInstance({file: fileTodo.pop()}).then((value) => {
+    handleWorkerFinished(w1);
+    return value;
+  }));
+  parallelProgress.push(w2.loadInstance({file: fileTodo.pop()}).then((value) => {
+    handleWorkerFinished(w2);
+    return value;
+  }));
+  parallelProgress.push(w3.loadInstance({file: fileTodo.pop()}).then((value) => {
+    handleWorkerFinished(w3);
+    return value;
+  }));
+
+  // const loaders = files.map((file) => {
+  //   return lld.loadInstance({file});
+  // });
+  Promise.all(parallelProgress)
+    .then((seriesLoaded) => {
+      console.timeEnd('someFunction');
       // make a proper function for this guy...
-      let series = loader.data[0].mergeSeries(loader.data)[0];
-      let stack = series.stack[0];
-      stackHelper = new HelpersStack(stack);
-      stackHelper.bbox.color = 0xf9f9f9;
-      stackHelper.border.color = 0xf9f9f9;
-      scene.add(stackHelper);
+      // let series = seriesLoaded[0].mergeSeries(seriesLoaded)[0];
+      // window.console.log(series);
+      // let stack = series.stack[0];
+      // stackHelper = new HelpersStack(stack);
+      // stackHelper.bbox.color = 0xf9f9f9;
+      // stackHelper.border.color = 0xf9f9f9;
+      // scene.add(stackHelper);
 
-      // update camrea's and control's target
-      let centerLPS = stackHelper.stack.worldCenter();
-      camera.lookAt(centerLPS.x, centerLPS.y, centerLPS.z);
-      camera.updateProjectionMatrix();
-      controls.target.set(centerLPS.x, centerLPS.y, centerLPS.z);
+      // window.console.log(stack.ijk2LPS);
 
-      loader.free();
-      loader = null;
 
-      function onWindowResize() {
-        camera.aspect = window.innerWidth / window.innerHeight;
-        camera.updateProjectionMatrix();
+      // // update camrea's and control's target
+      // let centerLPS = stackHelper.stack.worldCenter();
+      // camera.lookAt(centerLPS.x, centerLPS.y, centerLPS.z);
+      // camera.updateProjectionMatrix();
+      // controls.target.set(centerLPS.x, centerLPS.y, centerLPS.z);
 
-        renderer.setSize(window.innerWidth, window.innerHeight);
-      }
+      // function onWindowResize() {
+      //   camera.aspect = window.innerWidth / window.innerHeight;
+      //   camera.updateProjectionMatrix();
 
-      window.addEventListener('resize', onWindowResize, false);
+      //   renderer.setSize(window.innerWidth, window.innerHeight);
+      // }
 
-      // force 1st render
-      render();
-      // notify puppeteer to take screenshot
-      const puppetDiv = document.createElement('div');
-      puppetDiv.setAttribute('id', 'puppeteer');
-      document.body.appendChild(puppetDiv);
+      // window.addEventListener('resize', onWindowResize, false);
+
+      // // force 1st render
+      // render();
+      // // notify puppeteer to take screenshot
+      // const puppetDiv = document.createElement('div');
+      // puppetDiv.setAttribute('id', 'puppeteer');
+      // document.body.appendChild(puppetDiv);
     })
     .catch(function(error) {
       window.console.log('oops... something went wrong...');

--- a/examples/viewers_quadview/index.html
+++ b/examples/viewers_quadview/index.html
@@ -17,14 +17,15 @@
 <body>
 	<div id="my-gui-container"></div>
 
-	<div class="visualizer">
-		<div id="r0" class="renderer"></div>
-		<div id="r1" class="renderer"></div>
-		<div id="r2" class="renderer"></div>
-		<div id="r3" class="renderer"></div>
-	</div>
+<div class="visualizer">
+    <div id="r0" class="renderer"></div>
+    <div id="r1" class="renderer"></div>
+    <div id="r2" class="renderer"></div>
+    <div id="r3" class="renderer"></div>
+</div>
 
-	<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/FNNDSC/ami@master/src/loaders/loaders.freesurfer.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/FNNDSC/ami@dev/src/loaders/loaders.freesurfer.js"></script>
+
 	<script type="text/javascript" src="viewers_quadview.js"></script>
 
 	<!-- google analytics -->

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+declare module "worker-loader!*" {
+    class WebpackWorker extends Worker {
+      constructor();
+    }
+  
+    export default WebpackWorker;
+  }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,9 +1,13 @@
 ('use strict');
 
+const path = require('path');
+
 process.env.CHROME_BIN = require('puppeteer').executablePath();
 
 module.exports = function(karma) {
   karma.set({
+    basePath: '',
+
     // frameworks to use
     frameworks: ['jasmine', 'sinon'],
 
@@ -13,7 +17,7 @@ module.exports = function(karma) {
       `https://unpkg.com/three@latest/build/three.min.js`,
       // ,
       // 'specs/core/*.spec.*s',
-      'specs/**/*.spec.*s',
+      'specs/loaders/loaders2.spec.*s',
       { pattern: 'data/**/*', included: false, watched: false, served: true },
     ],
 
@@ -37,8 +41,8 @@ module.exports = function(karma) {
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
     logLevel: karma.LOG_WARN,
 
-    autoWatch: false,
-    singleRun: true,
+    autoWatch: true,
+    // singleRun: true,
     colors: true,
     webpack: {
       resolve: {
@@ -50,6 +54,12 @@ module.exports = function(karma) {
             test: /\.js$/,
             loader: 'babel-loader',
             exclude: [/node_modules/, /external/],
+          },
+          {
+            test: /\.worker\.ts$/,
+            use: {
+            loader: 'worker-loader',
+          }
           },
           {
             test: /\.ts$/,

--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
     "webpack-bundle-analyzer": "^2.9.0",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.5",
-    "webpack-watch-livereload-plugin": "^0.0.1"
+    "webpack-watch-livereload-plugin": "^0.0.1",
+    "worker-loader": "^2.0.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/specs/loaders/loaders2.spec.ts
+++ b/specs/loaders/loaders2.spec.ts
@@ -1,0 +1,70 @@
+import Loader2 from '../../src/loaders/loaders2';
+
+describe('Worker Loader', () => {
+  const sourceUrl = '/base/data/dicom/adi_slice.dcm';
+
+  describe('Loading a file', () => {
+    it('should receive all events ordered', async () => {
+      const startMessage = 'start';
+      const fetchMessages = ['fetchstart', 'fetchprogress', 'fetch', 'fetchend'];
+      const parseMessages = ['parsestart', 'parse', 'parseend'];
+      const endMessage = 'end';
+      const expectedSequence = [startMessage, ...fetchMessages, ...parseMessages, endMessage];
+
+      const results = [] as string[];
+
+      const loader = new Loader2();
+      loader.addEventListener('start', () => results.push('start'));
+      loader.addEventListener('end', () => results.push('end'));
+    
+      loader.addEventListener('fetchstart', () => results.push('fetchstart'));
+      loader.addEventListener('fetchend', () => results.push('fetchend'))
+      loader.addEventListener('fetch', () => results.push('fetch'))
+      loader.addEventListener('fetchprogress', () => !results.includes('fetchprogress') ? results.push('fetchprogress') : null);
+
+      loader.addEventListener('parsestart', () => results.push('parsestart'));
+      loader.addEventListener('parseend', () => results.push('parseend'))
+      loader.addEventListener('parse', () => results.push('parse'))
+
+      await loader.loadInstance({file: sourceUrl});
+
+      expect(results.join()).toEqual(expectedSequence.join());
+
+    });
+
+    it('should receive fetch progress', async () => {
+      const loader = new Loader2();
+      let loaded = 0;
+
+      loader.addEventListener('fetchprogress', (event) => {
+        loaded = event.loaded;
+      });
+
+      await loader.loadInstance({file: sourceUrl});
+
+      expect(loaded).toBeGreaterThan(0);
+    });
+
+    it('should error gracefully', async () => {
+      const loader = new Loader2();
+
+      let serverError = false;
+      let rejectPromise = false;
+      loader.addEventListener('fetcherror', (event) => {
+        serverError = true;
+      });
+
+      await loader.loadInstance({file: 'incorrect URL'}).catch(() => rejectPromise = true);
+
+      expect(serverError).toBeTruthy();
+      expect(rejectPromise).toBeTruthy();
+      
+      // test with incorrect data too -> parse error
+      // 
+
+      // test with 1 good and 1 bad
+
+
+    });
+  });
+});

--- a/src/loaders/dicom.worker.ts
+++ b/src/loaders/dicom.worker.ts
@@ -1,0 +1,115 @@
+import ParsersDicom from '../parsers/parsers.dicom';
+
+const ctx: Worker = self as any;
+
+ctx.onmessage = (message) => {
+    switch(message.data.type) {
+      case 'parsestart':
+            const volumeParser = new ParsersDicom({buffer: message.data.arrayBuffer}, 0);
+            // get all the series / stack / frame information for this file
+            // return it as a string
+            // const rawHeader = volumeParser.rawHeader()
+            
+            // series;
+            // seriesDescription obj?
+            const seriesInformation = {} as any;
+            // seriesInformation.rawHeader = volumeParser.rawHeader();
+            // global information
+            seriesInformation.seriesInstanceUID = volumeParser.seriesInstanceUID();
+            seriesInformation.transferSyntaxUID = volumeParser.transferSyntaxUID();
+            seriesInformation.seriesDate = volumeParser.seriesDate();
+            seriesInformation.seriesDescription = volumeParser.seriesDescription();
+            seriesInformation.studyDate = volumeParser.studyDate();
+            seriesInformation.studyDescription = volumeParser.studyDescription();
+            seriesInformation.numberOfFrames = volumeParser.numberOfFrames();
+            if (!seriesInformation.numberOfFrames) {
+              seriesInformation.numberOfFrames = 1;
+            }
+            seriesInformation.numberOfChannels = volumeParser.numberOfChannels();
+            seriesInformation.modality = volumeParser.modality();
+            // if it is a DICOM segmentation, attach extra information
+            if (seriesInformation.modality === 'SEG') {
+              seriesInformation.segmentationType = volumeParser.segmentationType();
+              seriesInformation.segmentationSegments = volumeParser.segmentationSegments();
+            }
+            // patient information
+            seriesInformation.patientID = volumeParser.patientID();
+            seriesInformation.patientName = volumeParser.patientName();
+            seriesInformation.patientAge = volumeParser.patientAge();
+            seriesInformation.patientBirthdate = volumeParser.patientBirthdate();
+            seriesInformation.patientSex = volumeParser.patientSex();
+    
+            const stackInformation = {} as any;
+            stackInformation.numberOfChannels = volumeParser.numberOfChannels();
+            stackInformation.pixelRepresentation = volumeParser.pixelRepresentation();
+            stackInformation.pixelType = volumeParser.pixelType();
+            stackInformation.invert = volumeParser.invert();
+            stackInformation.spacingBetweenSlices = volumeParser.spacingBetweenSlices();
+            stackInformation.modality = seriesInformation.modality;
+            // if it is a DICOM segmentation, attach extra information
+            if (stackInformation.modality === 'SEG') {
+              stackInformation.segmentationType = seriesInformation.segmentationType;
+              stackInformation.segmentationSegments = seriesInformation.segmentationSegments;
+            }
+
+            // parse all frames from file
+            const framesInformation  = [] as any;
+            const framesPixelDataBuffer  = [] as ArrayBuffer[];
+            const framesPixelData  = [] as any[];
+
+            for (let i = 0; i < seriesInformation.numberOfFrames; i++) {
+                const frameInformation = {} as any;
+                frameInformation.sopInstanceUID = volumeParser.sopInstanceUID(i);
+                frameInformation.url = 'filename not set';
+                frameInformation.index = i;
+                frameInformation.invert = stackInformation.invert;
+                frameInformation.frameTime = volumeParser.frameTime(i);
+                frameInformation.ultrasoundRegions = volumeParser.ultrasoundRegions(i);
+                frameInformation.rows = volumeParser.rows(i);
+                frameInformation.columns = volumeParser.columns(i);
+                frameInformation.numberOfChannels = stackInformation.numberOfChannels;
+                frameInformation.pixelPaddingValue = volumeParser.pixelPaddingValue(i);
+                frameInformation.pixelRepresentation = stackInformation.pixelRepresentation;
+                frameInformation.pixelType = stackInformation.pixelType;
+                frameInformation.pixelSpacing = volumeParser.pixelSpacing(i);
+                frameInformation.spacingBetweenSlices = volumeParser.spacingBetweenSlices(i);
+                frameInformation.sliceThickness = volumeParser.sliceThickness(i);
+                frameInformation.imageOrientation = volumeParser.imageOrientation(i);
+                frameInformation.rightHanded = volumeParser.rightHanded();
+                stackInformation.rightHanded = frameInformation.rightHanded;
+                if (frameInformation.imageOrientation === null) {
+                    frameInformation.imageOrientation = [1, 0, 0, 0, 1, 0];
+                }
+                frameInformation.imagePosition = volumeParser.imagePosition(i);
+                frameInformation.dimensionIndexValues = volumeParser.dimensionIndexValues(i);
+                frameInformation.bitsAllocated = volumeParser.bitsAllocated(i);
+                frameInformation.instanceNumber = volumeParser.instanceNumber(i);
+                frameInformation.windowCenter = volumeParser.windowCenter(i);
+                frameInformation.windowWidth = volumeParser.windowWidth(i);
+                frameInformation.rescaleSlope = volumeParser.rescaleSlope(i);
+                frameInformation.rescaleIntercept = volumeParser.rescaleIntercept(i);
+                // should pass frame index for consistency...
+                const pixelData = volumeParser.extractPixelData(i);
+                frameInformation.minMax = volumeParser.minMaxPixelData(pixelData);
+                frameInformation.byteOffset = 0 + pixelData.byteOffset;
+                frameInformation.byteLength = 0 + pixelData.byteLength;
+
+                // if series.mo
+                if (seriesInformation.modality === 'SEG') {
+                    frameInformation.referencedSegmentNumber = volumeParser.referencedSegmentNumber(i);
+                }
+
+                framesInformation.push(frameInformation);
+                framesPixelData.push(pixelData);
+                framesPixelDataBuffer.push(pixelData.buffer);
+            }
+  
+            ctx.postMessage({type: 'parse', framesInformation: JSON.stringify(framesInformation), seriesInformation: JSON.stringify(seriesInformation), stackInformation: JSON.stringify(stackInformation), framesPixelData}, framesPixelDataBuffer);
+            ctx.postMessage({type: 'parseend'});
+        break;
+        default:
+        break;
+    }
+};
+
+export default {} as typeof Worker & {new (): Worker};

--- a/src/loaders/dicomFetcher.worker.ts
+++ b/src/loaders/dicomFetcher.worker.ts
@@ -1,0 +1,234 @@
+import ParsersDicom from '../parsers/parsers.dicom';
+
+const ctx: Worker = self as any;
+
+// setup xhr request with all listeners
+const request = new XMLHttpRequest();
+request.addEventListener('load', () => {
+  const arrayBuffer = request.response;
+  if (request.readyState === 4 && request.status === 200 && arrayBuffer) {
+      // ctx.postMessage({type: 'fetch', arrayBuffer}, [arrayBuffer]);
+      const volumeParser = new ParsersDicom({buffer: arrayBuffer}, 0);
+      // get all the series / stack / frame information for this file
+      // return it as a string
+      // const rawHeader = volumeParser.rawHeader()
+      
+      // series;
+      // seriesDescription obj?
+      const seriesInformation = {} as any;
+      // seriesInformation.rawHeader = volumeParser.rawHeader();
+      // global information
+      seriesInformation.seriesInstanceUID = volumeParser.seriesInstanceUID();
+      seriesInformation.transferSyntaxUID = volumeParser.transferSyntaxUID();
+      seriesInformation.seriesDate = volumeParser.seriesDate();
+      seriesInformation.seriesDescription = volumeParser.seriesDescription();
+      seriesInformation.studyDate = volumeParser.studyDate();
+      seriesInformation.studyDescription = volumeParser.studyDescription();
+      seriesInformation.numberOfFrames = volumeParser.numberOfFrames();
+      if (!seriesInformation.numberOfFrames) {
+        seriesInformation.numberOfFrames = 1;
+      }
+      seriesInformation.numberOfChannels = volumeParser.numberOfChannels();
+      seriesInformation.modality = volumeParser.modality();
+      // if it is a DICOM segmentation, attach extra information
+      if (seriesInformation.modality === 'SEG') {
+        seriesInformation.segmentationType = volumeParser.segmentationType();
+        seriesInformation.segmentationSegments = volumeParser.segmentationSegments();
+      }
+      // patient information
+      seriesInformation.patientID = volumeParser.patientID();
+      seriesInformation.patientName = volumeParser.patientName();
+      seriesInformation.patientAge = volumeParser.patientAge();
+      seriesInformation.patientBirthdate = volumeParser.patientBirthdate();
+      seriesInformation.patientSex = volumeParser.patientSex();
+
+      const stackInformation = {} as any;
+      stackInformation.numberOfChannels = volumeParser.numberOfChannels();
+      stackInformation.pixelRepresentation = volumeParser.pixelRepresentation();
+      stackInformation.pixelType = volumeParser.pixelType();
+      stackInformation.invert = volumeParser.invert();
+      stackInformation.spacingBetweenSlices = volumeParser.spacingBetweenSlices();
+      stackInformation.modality = seriesInformation.modality;
+      // if it is a DICOM segmentation, attach extra information
+      if (stackInformation.modality === 'SEG') {
+        stackInformation.segmentationType = seriesInformation.segmentationType;
+        stackInformation.segmentationSegments = seriesInformation.segmentationSegments;
+      }
+
+      // parse all frames from file
+      const framesInformation  = [] as any;
+      const framesPixelDataBuffer  = [] as ArrayBuffer[];
+      const framesPixelData  = [] as any[];
+
+      for (let i = 0; i < seriesInformation.numberOfFrames; i++) {
+          const frameInformation = {} as any;
+          frameInformation.sopInstanceUID = volumeParser.sopInstanceUID(i);
+          frameInformation.url = 'filename not set';
+          frameInformation.index = i;
+          frameInformation.invert = stackInformation.invert;
+          frameInformation.frameTime = volumeParser.frameTime(i);
+          frameInformation.ultrasoundRegions = volumeParser.ultrasoundRegions(i);
+          frameInformation.rows = volumeParser.rows(i);
+          frameInformation.columns = volumeParser.columns(i);
+          frameInformation.numberOfChannels = stackInformation.numberOfChannels;
+          frameInformation.pixelPaddingValue = volumeParser.pixelPaddingValue(i);
+          frameInformation.pixelRepresentation = stackInformation.pixelRepresentation;
+          frameInformation.pixelType = stackInformation.pixelType;
+          frameInformation.pixelSpacing = volumeParser.pixelSpacing(i);
+          frameInformation.spacingBetweenSlices = volumeParser.spacingBetweenSlices(i);
+          frameInformation.sliceThickness = volumeParser.sliceThickness(i);
+          frameInformation.imageOrientation = volumeParser.imageOrientation(i);
+          frameInformation.rightHanded = volumeParser.rightHanded();
+          stackInformation.rightHanded = frameInformation.rightHanded;
+          if (frameInformation.imageOrientation === null) {
+              frameInformation.imageOrientation = [1, 0, 0, 0, 1, 0];
+          }
+          frameInformation.imagePosition = volumeParser.imagePosition(i);
+          frameInformation.dimensionIndexValues = volumeParser.dimensionIndexValues(i);
+          frameInformation.bitsAllocated = volumeParser.bitsAllocated(i);
+          frameInformation.instanceNumber = volumeParser.instanceNumber(i);
+          frameInformation.windowCenter = volumeParser.windowCenter(i);
+          frameInformation.windowWidth = volumeParser.windowWidth(i);
+          frameInformation.rescaleSlope = volumeParser.rescaleSlope(i);
+          frameInformation.rescaleIntercept = volumeParser.rescaleIntercept(i);
+          // should pass frame index for consistency...
+          const pixelData = volumeParser.extractPixelData(i);
+          frameInformation.minMax = volumeParser.minMaxPixelData(pixelData);
+          frameInformation.byteOffset = 0 + pixelData.byteOffset;
+          frameInformation.byteLength = 0 + pixelData.byteLength;
+
+          // if series.mo
+          if (seriesInformation.modality === 'SEG') {
+              frameInformation.referencedSegmentNumber = volumeParser.referencedSegmentNumber(i);
+          }
+
+          framesInformation.push(frameInformation);
+          framesPixelData.push(pixelData);
+          framesPixelDataBuffer.push(pixelData.buffer);
+      }
+
+      ctx.postMessage({type: 'parse', framesInformation, seriesInformation, stackInformation, framesPixelData}, framesPixelDataBuffer);
+      ctx.postMessage({type: 'parseend'});
+  } else {
+    // server error retrieveing data
+    ctx.postMessage({type: 'fetcherror'});
+  }
+});
+
+ctx.onmessage = (message) => {
+    switch(message.data.type) {
+      case 'fetchstart':
+        const file = message.data.file as string;
+        request.open('GET', file);
+        request.responseType = 'arraybuffer';
+        request.send();
+        break;
+      case 'parsestart':
+            // const volumeParser = new ParsersDicom({buffer: message.data.arrayBuffer}, 0);
+            // // get all the series / stack / frame information for this file
+            // // return it as a string
+            // // const rawHeader = volumeParser.rawHeader()
+            
+            // // series;
+            // // seriesDescription obj?
+            // const seriesInformation = {} as any;
+            // // seriesInformation.rawHeader = volumeParser.rawHeader();
+            // // global information
+            // seriesInformation.seriesInstanceUID = volumeParser.seriesInstanceUID();
+            // seriesInformation.transferSyntaxUID = volumeParser.transferSyntaxUID();
+            // seriesInformation.seriesDate = volumeParser.seriesDate();
+            // seriesInformation.seriesDescription = volumeParser.seriesDescription();
+            // seriesInformation.studyDate = volumeParser.studyDate();
+            // seriesInformation.studyDescription = volumeParser.studyDescription();
+            // seriesInformation.numberOfFrames = volumeParser.numberOfFrames();
+            // if (!seriesInformation.numberOfFrames) {
+            //   seriesInformation.numberOfFrames = 1;
+            // }
+            // seriesInformation.numberOfChannels = volumeParser.numberOfChannels();
+            // seriesInformation.modality = volumeParser.modality();
+            // // if it is a DICOM segmentation, attach extra information
+            // if (seriesInformation.modality === 'SEG') {
+            //   seriesInformation.segmentationType = volumeParser.segmentationType();
+            //   seriesInformation.segmentationSegments = volumeParser.segmentationSegments();
+            // }
+            // // patient information
+            // seriesInformation.patientID = volumeParser.patientID();
+            // seriesInformation.patientName = volumeParser.patientName();
+            // seriesInformation.patientAge = volumeParser.patientAge();
+            // seriesInformation.patientBirthdate = volumeParser.patientBirthdate();
+            // seriesInformation.patientSex = volumeParser.patientSex();
+    
+            // const stackInformation = {} as any;
+            // stackInformation.numberOfChannels = volumeParser.numberOfChannels();
+            // stackInformation.pixelRepresentation = volumeParser.pixelRepresentation();
+            // stackInformation.pixelType = volumeParser.pixelType();
+            // stackInformation.invert = volumeParser.invert();
+            // stackInformation.spacingBetweenSlices = volumeParser.spacingBetweenSlices();
+            // stackInformation.modality = seriesInformation.modality;
+            // // if it is a DICOM segmentation, attach extra information
+            // if (stackInformation.modality === 'SEG') {
+            //   stackInformation.segmentationType = seriesInformation.segmentationType;
+            //   stackInformation.segmentationSegments = seriesInformation.segmentationSegments;
+            // }
+
+            // // parse all frames from file
+            // const framesInformation  = [] as any;
+            // const framesPixelDataBuffer  = [] as ArrayBuffer[];
+            // const framesPixelData  = [] as any[];
+
+            // for (let i = 0; i < seriesInformation.numberOfFrames; i++) {
+            //     const frameInformation = {} as any;
+            //     frameInformation.sopInstanceUID = volumeParser.sopInstanceUID(i);
+            //     frameInformation.url = 'filename not set';
+            //     frameInformation.index = i;
+            //     frameInformation.invert = stackInformation.invert;
+            //     frameInformation.frameTime = volumeParser.frameTime(i);
+            //     frameInformation.ultrasoundRegions = volumeParser.ultrasoundRegions(i);
+            //     frameInformation.rows = volumeParser.rows(i);
+            //     frameInformation.columns = volumeParser.columns(i);
+            //     frameInformation.numberOfChannels = stackInformation.numberOfChannels;
+            //     frameInformation.pixelPaddingValue = volumeParser.pixelPaddingValue(i);
+            //     frameInformation.pixelRepresentation = stackInformation.pixelRepresentation;
+            //     frameInformation.pixelType = stackInformation.pixelType;
+            //     frameInformation.pixelSpacing = volumeParser.pixelSpacing(i);
+            //     frameInformation.spacingBetweenSlices = volumeParser.spacingBetweenSlices(i);
+            //     frameInformation.sliceThickness = volumeParser.sliceThickness(i);
+            //     frameInformation.imageOrientation = volumeParser.imageOrientation(i);
+            //     frameInformation.rightHanded = volumeParser.rightHanded();
+            //     stackInformation.rightHanded = frameInformation.rightHanded;
+            //     if (frameInformation.imageOrientation === null) {
+            //         frameInformation.imageOrientation = [1, 0, 0, 0, 1, 0];
+            //     }
+            //     frameInformation.imagePosition = volumeParser.imagePosition(i);
+            //     frameInformation.dimensionIndexValues = volumeParser.dimensionIndexValues(i);
+            //     frameInformation.bitsAllocated = volumeParser.bitsAllocated(i);
+            //     frameInformation.instanceNumber = volumeParser.instanceNumber(i);
+            //     frameInformation.windowCenter = volumeParser.windowCenter(i);
+            //     frameInformation.windowWidth = volumeParser.windowWidth(i);
+            //     frameInformation.rescaleSlope = volumeParser.rescaleSlope(i);
+            //     frameInformation.rescaleIntercept = volumeParser.rescaleIntercept(i);
+            //     // should pass frame index for consistency...
+            //     const pixelData = volumeParser.extractPixelData(i);
+            //     frameInformation.minMax = volumeParser.minMaxPixelData(pixelData);
+            //     frameInformation.byteOffset = 0 + pixelData.byteOffset;
+            //     frameInformation.byteLength = 0 + pixelData.byteLength;
+
+            //     // if series.mo
+            //     if (seriesInformation.modality === 'SEG') {
+            //         frameInformation.referencedSegmentNumber = volumeParser.referencedSegmentNumber(i);
+            //     }
+
+            //     framesInformation.push(frameInformation);
+            //     framesPixelData.push(pixelData);
+            //     framesPixelDataBuffer.push(pixelData.buffer);
+            // }
+  
+            // ctx.postMessage({type: 'parse', framesInformation: JSON.stringify(framesInformation), seriesInformation: JSON.stringify(seriesInformation), stackInformation: JSON.stringify(stackInformation), framesPixelData}, framesPixelDataBuffer);
+            // ctx.postMessage({type: 'parseend'});
+        break;
+        default:
+        break;
+    }
+};
+
+export default {} as typeof Worker & {new (): Worker};

--- a/src/loaders/fetcher.worker.ts
+++ b/src/loaders/fetcher.worker.ts
@@ -1,0 +1,49 @@
+import { File } from './loaders2';
+
+const ctx: Worker = self as any;
+
+// setup xhr request with all listeners
+const request = new XMLHttpRequest();
+request.addEventListener('loadstart', () => {
+    ctx.postMessage({type: 'fetchstart'});
+});
+request.addEventListener('load', () => {
+    const arrayBuffer = request.response;
+    if (request.readyState === 4 && request.status === 200 && arrayBuffer) {
+        ctx.postMessage({type: 'fetch', arrayBuffer}, [arrayBuffer]);
+    } else {
+      // server error retrieveing data
+      ctx.postMessage({type: 'fetcherror'});
+    }
+});
+request.addEventListener('loadend', () => {
+    ctx.postMessage({type: 'fetchend'});
+});
+request.addEventListener('progress', (event) => {
+    ctx.postMessage({type: 'fetchprogress', loaded: event.loaded, total: event.total});
+});
+request.addEventListener('error', () => {
+    // network error
+    ctx.postMessage({type: 'fetcherror'});
+});
+request.addEventListener('abort', () => {
+    ctx.postMessage({type: 'fetchabort'});
+});
+
+ctx.onmessage = (message) => {
+    switch(message.data.type) {
+      case 'fetchstart':
+        const file = message.data.file as string;
+        request.open('GET', file);
+        request.responseType = 'arraybuffer';
+        request.send();
+        break;
+      case 'end':
+        ctx.postMessage({type: 'end'});
+        break;
+      default:
+        break;
+    }
+};
+
+export default {} as typeof Worker & {new (): Worker};

--- a/src/loaders/loaders2.ts
+++ b/src/loaders/loaders2.ts
@@ -1,0 +1,447 @@
+import { EventDispatcher } from 'three';
+import CoreUtils from '../core/core.utils';
+import ModelsFrame from '../models/models.frame';
+import ModelsSeries from '../models/models.series';
+import ModelsStack from '../models/models.stack';
+import DicomWorker from './dicom.worker';
+import DicomFetcherWorker from './dicomFetcher.worker';
+import FetcherWorker from './fetcher.worker';
+import MGHWorker from './mgh.worker';
+
+
+const PAKO = require('pako');
+
+/**
+ * Load = fetch over network and parse
+ * 
+ * Load file: loadInstance(brain.dcm) => return a series
+ * Load file with definition => loadInstance(brain.raw, definition.mdh) => return a series
+ * Load group of files => load([f1, f2.dcm, {file.dcm, definition}, file.mgh]) => return array of series
+ * 
+ * Dispatch events, do not manage progress bars
+ * Event: filename, progress, total, timeout, etc. all regular erros
+ * 
+ * Fetch and parse happen in a web worker! :D
+ * 
+ * typedef File: string;
+ * interface FileWithDefinition {
+ *   file: File,
+ *   definition: string,
+ * }
+ * 
+ * return model or series! using extension of file type or sth etc.
+ * 
+ * 1 worker per data type to have each worker as small as possible
+ * 
+ * dicomLoader.worker.ts -> obj + data in buffer -> need to support multiple frames
+ * // that is what we do in the loaders.volume
+ * niftiLoader.woker.ts -> obj + data in buffer
+ * mghLoader.worker.ts -> obj + data in buffer
+ * stlLoader.worker.ts -> obj + data in buffer // not geometry of mesh since it can not be passed through web workers
+ * gltfLoader.worker.ts -> obj + data in buffer
+ * trkLoader.worker.ts -> obj + data in buffer
+ *
+ * const loadFileInstance = (File) => {
+ *  // send information to web worker
+ *  // get progress result
+ *  // reconstruct results
+ * // in obj return we have a flag per obj type ? mesh or lines or series?
+ * // return constructMeshFromWorker();
+ *  // return constructSeriesFromWorker(); // that is what we do in the loaders.volume
+ *  // return constructLinesFromWorker();
+ * }
+ * 
+ * const loadFileWithDefinitionInstance = (FileWithDefinition) => {
+ *  // send information to web worker
+ *  // get progress result
+ *  // reconstruct results
+ * }
+ * 
+ * const loadInstance = async (File | FileWithDefinition ) => {
+ *  if (isFileWithDefinition) {
+ *   // fetch definition
+ * }
+ * 
+ * // fetch the data
+ * 
+ * // parse the data
+ * }
+ * 
+ * const load = async (File[] | FileWithDefinition[]) => {
+ *
+ * // multiple promise wait for all
+ * // load instance
+ * // loadInstace(file);
+ * }
+ * 
+ * const loadMultiple
+ * 
+ * Streaming support ?
+ * How do we listen to progress ?
+ */
+
+export interface File {
+  file: string;
+  definition?: string;
+}
+
+export interface FileMeta {
+    filename: string,
+    extension: string,
+    pathname: string,
+    query: string,
+    gzCompressed: boolean,
+}
+
+// general events
+const startEvent = { type: 'start', file: '', definition: '' };
+const endEvent = { type: 'end', file: '', definition: '' };
+
+// fetch events
+const fetchStartEvent = { type: 'fetchstart', file: '', definition: '' };
+const fetchEvent = { type: 'fetch', file: '', definition: '' };
+const fetchEndEvent = { type: 'fetchend', file: '', definition: '' };
+const fetchProgressEvent = { type: 'fetchprogress', file: '', definition: '', loaded: -1, total: -1};
+const fetchErrorEvent = { type: 'fetcherror', file: '', definition: '' };
+const fetchAbortEvent = { type: 'fetchabort', file: '', definition: '' };
+
+// parse events
+const parseStartEvent = { type: 'parsestart', file: '', definition: '' };
+const parseEvent = { type: 'parse', file: '', definition: '' };
+const parseErrorEvent = { type: 'parseerror', file: '', definition: '' };
+const parseEndEvent = { type: 'parseend', file: '', definition: '' };
+
+export default class WorkerLoader extends EventDispatcher {
+
+ private fetch = async (file: string) => {
+  const fetcherWorker = new FetcherWorker();
+  let arrayBuffer : ArrayBuffer;
+  let fetchSuccess = false;
+  await new Promise((resolve, reject) => {
+    fetcherWorker.onmessage = (message) => {
+      switch(message.data.type) {
+        case 'fetchstart':
+          fetchStartEvent.file = file;
+          this.dispatchEvent(fetchStartEvent);
+          break;
+        case 'fetch':
+          fetchEvent.file = file;
+          this.dispatchEvent(fetchEvent);
+          arrayBuffer = message.data.arrayBuffer;
+          fetchSuccess = true;
+          break;
+        case 'fetchend':
+          fetchEndEvent.file = file;
+          this.dispatchEvent(fetchEndEvent);
+          if (fetchSuccess) {
+            resolve(arrayBuffer);
+          } else {
+            reject();
+          }
+          break;
+        case 'fetchprogress':
+          fetchProgressEvent.file = file;
+          fetchProgressEvent.loaded = message.data.loaded;
+          fetchProgressEvent.total = message.data.total;
+          this.dispatchEvent(fetchProgressEvent);
+          break;
+        case 'fetcherror':
+          fetchErrorEvent.file = file;
+          this.dispatchEvent(fetchErrorEvent);
+          reject();
+          break;
+        case 'fetchabort':
+          fetchProgressEvent.file = file;
+          this.dispatchEvent(fetchAbortEvent);
+          reject();
+          break;
+        default:
+          break;
+      }
+    };
+    fetcherWorker.postMessage({type: 'fetchstart', file});
+  });
+
+  return {arrayBuffer, fetchSuccess};
+ }
+
+ private extractMetaInformationFrom = (file: string) => {
+  const parsedUrl = CoreUtils.parseUrl(file);
+  // update data
+  const filename = parsedUrl.filename;
+  let extension = parsedUrl.extension;
+  const pathname = parsedUrl.pathname;
+  const query = parsedUrl.query;
+  let gzCompressed = false;
+
+  // unzip if extension is '.gz'
+  if (extension === 'gz') {
+    gzCompressed = true;
+    extension = filename
+      .split('.gz')
+      .shift()
+      .split('.')
+      .pop();
+  } else if (extension === 'mgz') {
+    gzCompressed = true;
+    extension = 'mgh';
+  } else if (extension === 'zraw') {
+    gzCompressed = true;
+    extension = 'raw';
+  }
+
+  return {
+    filename,
+    extension,
+    pathname,
+    query,
+    gzCompressed,
+  } as FileMeta;
+}
+
+private parserWorkerForFile = (fileMeta: FileMeta) => {
+    let Worker = null;
+
+    switch (fileMeta.extension.toUpperCase()) {
+      // case 'NII':
+      // case 'NII_':
+      //   Parser = ParsersNifti;
+      //   break;
+      case 'DCM':
+      case 'DIC':
+      case 'DICOM':
+      case 'IMA':
+      case '':
+        Worker = DicomWorker;
+        break;
+      // case 'MHD':
+      //   Parser = ParsersMhd;
+      //   break;
+      // case 'NRRD':
+      //   Parser = ParsersNrrd;
+      //   break;
+      case 'MGH':
+      case 'MGZ':
+        Worker = MGHWorker;
+        break;
+      default:
+        console.warn('unsupported extension: ' + fileMeta.extension);
+        return false;
+    }
+    return Worker;
+  }
+
+ private parse = async (file: string, rawArrayBuffer: ArrayBuffer) => {
+
+  // pre-process file and buffer
+  const fileMeta = this.extractMetaInformationFrom(file);
+  let arrayBuffer = rawArrayBuffer;
+  if (fileMeta.gzCompressed) {
+    arrayBuffer = PAKO.inflate(rawArrayBuffer).buffer;
+  }
+
+
+  // get proper worker
+  const ParseWorker = this.parserWorkerForFile(fileMeta);
+  const parserWorker = new ParseWorker();
+  let seriesInformation = {} as any;
+  let stackInformation = {} as any;
+  let framesInformation = {} as any;
+  let framesPixelData = [] as ArrayBuffer[];
+  let parseSuccess = false;
+  await new Promise((resolve, reject) => {
+    parserWorker.onmessage = (message) => {
+      switch(message.data.type) {
+        case 'parse':
+          seriesInformation = JSON.parse(message.data.seriesInformation);
+          stackInformation = JSON.parse(message.data.stackInformation);
+          framesInformation = JSON.parse(message.data.framesInformation);
+          framesPixelData = message.data.framesPixelData;
+          parseEvent.file = file;
+          this.dispatchEvent(parseEvent);
+          parseSuccess = true;
+          break;
+        case 'parseerror':
+          parseErrorEvent.file = file;
+          this.dispatchEvent(parseErrorEvent);
+          break;
+        case 'parseend':
+          parseEndEvent.file = file;
+          this.dispatchEvent(parseEndEvent);
+          if (parseSuccess) {
+            resolve();
+          } else {
+            reject();
+          }
+          break;
+        default:
+          break;
+      }
+    };
+    parseStartEvent.file = file;
+    this.dispatchEvent(parseStartEvent);
+    parserWorker.postMessage({type: 'parsestart', arrayBuffer}, [arrayBuffer]);
+  });
+
+  return {parseSuccess, seriesInformation, stackInformation, framesInformation, framesPixelData};
+ }
+
+ private fetchAndParse = async (file: string) => {
+  // get proper worker
+  const parserWorker = new DicomFetcherWorker();
+  let seriesInformation = {} as any;
+  let stackInformation = {} as any;
+  let framesInformation = {} as any;
+  let framesPixelData = [] as ArrayBuffer[];
+  let parseSuccess = false;
+  await new Promise((resolve, reject) => {
+    parserWorker.onmessage = (message) => {
+      switch(message.data.type) {
+        case 'parse':
+          seriesInformation = message.data.seriesInformation;
+          stackInformation = message.data.stackInformation;
+          framesInformation = message.data.framesInformation;
+          framesPixelData = message.data.framesPixelData;
+          parseEvent.file = file;
+          this.dispatchEvent(parseEvent);
+          parseSuccess = true;
+          break;
+        case 'parseerror':
+          parseErrorEvent.file = file;
+          this.dispatchEvent(parseErrorEvent);
+          break;
+        case 'parseend':
+          parseEndEvent.file = file;
+          this.dispatchEvent(parseEndEvent);
+          if (parseSuccess) {
+            resolve();
+          } else {
+            reject();
+          }
+          break;
+        default:
+          break;
+      }
+    };
+    parseStartEvent.file = file;
+    this.dispatchEvent(parseStartEvent);
+    parserWorker.postMessage({type: 'fetchstart', file});
+  });
+
+  return {parseSuccess, seriesInformation, stackInformation, framesInformation, framesPixelData};
+ }
+
+ public loadInstance = async (data: File) => {
+  this.dispatchEvent(startEvent);
+
+  // load file instance in web worker
+  if (data.definition !== undefined) {
+    // do something special?
+    // maybe not
+  }
+
+  // // fetch
+  // const {arrayBuffer, fetchSuccess} = await this.fetch(data.file);
+  // if (!fetchSuccess) {
+  //   return Promise.reject(`Could not fetch ${data.file}`);
+  // }
+
+  // // parse
+  // const {parseSuccess, seriesInformation, stackInformation, framesInformation, framesPixelData} = await this.parse(data.file, arrayBuffer);
+  // if (!parseSuccess) {
+  //   return Promise.reject(`Could not parse ${data.file}`);
+  // }
+  
+  const {parseSuccess, seriesInformation, stackInformation, framesInformation, framesPixelData} = await this.fetchAndParse(data.file);
+    if (!parseSuccess) {
+    return Promise.reject(`Could not parse ${data.file}`);
+  }
+  // reconstruct the object and initialize it!
+  // create a series
+  const series = new ModelsSeries();
+  // global information
+  series.seriesInstanceUID = seriesInformation.seriesInstanceUID;
+  series.transferSyntaxUID = seriesInformation.transferSyntaxUID;
+  series.seriesDate = seriesInformation.seriesDate;
+  series.seriesDescription = seriesInformation.seriesDescription;
+  series.studyDate = seriesInformation.studyDate;
+  series.studyDescription = seriesInformation.studyDescription;
+  series.numberOfFrames = seriesInformation.numberOfFrames;
+
+  series.numberOfChannels = seriesInformation.numberOfChannels;
+  series.modality = seriesInformation.modality;
+  // if it is a segmentation, attach extra information
+  if (series.modality === 'SEG') {
+    series.segmentationType = seriesInformation.segmentationType;
+    series.segmentationSegments = seriesInformation.segmentationSegments;
+  }
+  // patient information
+  series.patientID = seriesInformation.patientID;
+  series.patientName = seriesInformation.patientName;
+  series.patientAge = seriesInformation.patientAge;
+  series.patientBirthdate = seriesInformation.patientBirthdate;
+  series.patientSex = seriesInformation.patientSex;
+
+
+  // just create 1 dummy stack for now
+  const stack = new ModelsStack();
+  stack.numberOfChannels = stackInformation.numberOfChannels;
+  stack.pixelRepresentation = stackInformation.pixelRepresentation;
+  stack.pixelType = stackInformation.pixelType;
+  stack.invert = stackInformation.invert;
+  stack.spacingBetweenSlices = stackInformation.spacingBetweenSlices;
+  stack.modality = series.modality;
+  // if it is a segmentation, attach extra information
+  if (stack.modality === 'SEG') {
+    // colors
+    // labels
+    // etc.
+    stack.segmentationType = series.segmentationType;
+    stack.segmentationSegments = series.segmentationSegments;
+  }
+  series.stack.push(stack);
+
+  framesInformation.forEach((element, index) => {
+    const frame = new ModelsFrame();
+    frame.sopInstanceUID = element.sopInstanceUID;
+    frame.url = index;
+    frame.index = element.index;
+    frame.invert = stack.invert;
+    frame.frameTime = element.frameTime;
+    frame.ultrasoundRegions = element.ultrasoundRegions;
+    frame.rows = element.rows;
+    frame.columns = element.columns;
+    frame.numberOfChannels = stack.numberOfChannels;
+    frame.pixelPaddingValue = element.pixelPaddingValue;
+    frame.pixelRepresentation = stack.pixelRepresentation;
+    frame.pixelType = stack.pixelType;
+    frame.pixelData = framesPixelData[index];
+    frame.pixelSpacing = element.pixelSpacing;
+    frame.spacingBetweenSlices = element.spacingBetweenSlices;
+    frame.sliceThickness = element.sliceThickness;
+    frame.imageOrientation = element.imageOrientation;
+    frame.rightHanded = element.rightHanded;
+    stack.rightHanded = frame.rightHanded;
+    frame.imagePosition = element.imagePosition;
+    frame.dimensionIndexValues = element.dimensionIndexValues;
+    frame.bitsAllocated = element.bitsAllocated;
+    frame.instanceNumber = element.instanceNumber;
+    frame.windowCenter = element.windowCenter;
+    frame.windowWidth = element.windowWidth;
+    frame.rescaleSlope = element.rescaleSlope;
+    frame.rescaleIntercept = element.rescaleIntercept;
+    frame.minMax = element.minMax;
+
+    // if series.mo
+    if (series.modality === 'SEG') {
+      frame.referencedSegmentNumber = element.referencedSegmentNumber;
+    }
+
+    stack.frame.push(frame);
+  });
+
+  endEvent.file = data.file;
+  this.dispatchEvent(endEvent);
+  return series;
+}
+}

--- a/src/loaders/mgh.worker.ts
+++ b/src/loaders/mgh.worker.ts
@@ -1,0 +1,113 @@
+import ParserMGH from '../parsers/parsers.mgh';
+
+const ctx: Worker = self as any;
+
+ctx.onmessage = (message) => {
+    switch(message.data.type) {
+      case 'parsestart':
+            const volumeParser = new ParserMGH({buffer: message.data.arrayBuffer}, 0);
+            // get all the series / stack / frame information for this file
+            // return it as a string
+            // const rawHeader = volumeParser.rawHeader()
+            
+            // series;
+            // seriesDescription obj?
+            const seriesInformation = {} as any;
+            // seriesInformation.rawHeader = volumeParser.rawHeader();
+            // global information
+            seriesInformation.seriesInstanceUID = volumeParser.seriesInstanceUID();
+            seriesInformation.transferSyntaxUID = volumeParser.transferSyntaxUID();
+            seriesInformation.seriesDate = volumeParser.seriesDate();
+            seriesInformation.seriesDescription = volumeParser.seriesDescription();
+            seriesInformation.studyDate = volumeParser.studyDate();
+            seriesInformation.studyDescription = volumeParser.studyDescription();
+            seriesInformation.numberOfFrames = volumeParser.numberOfFrames();
+            if (!seriesInformation.numberOfFrames) {
+              seriesInformation.numberOfFrames = 1;
+            }
+            seriesInformation.numberOfChannels = volumeParser.numberOfChannels();
+            seriesInformation.modality = volumeParser.modality();
+            // if it is a DICOM segmentation, attach extra information
+            if (seriesInformation.modality === 'SEG') {
+              seriesInformation.segmentationType = volumeParser.segmentationType();
+              seriesInformation.segmentationSegments = volumeParser.segmentationSegments();
+            }
+            // patient information
+            seriesInformation.patientID = volumeParser.patientID();
+            seriesInformation.patientName = volumeParser.patientName();
+            seriesInformation.patientAge = volumeParser.patientAge();
+            seriesInformation.patientBirthdate = volumeParser.patientBirthdate();
+            seriesInformation.patientSex = volumeParser.patientSex();
+    
+            const stackInformation = {} as any;
+            stackInformation.numberOfChannels = volumeParser.numberOfChannels();
+            stackInformation.pixelRepresentation = volumeParser.pixelRepresentation();
+            stackInformation.pixelType = volumeParser.pixelType();
+            stackInformation.invert = volumeParser.invert();
+            stackInformation.spacingBetweenSlices = volumeParser.spacingBetweenSlices();
+            stackInformation.modality = seriesInformation.modality;
+            // if it is a DICOM segmentation, attach extra information
+            if (stackInformation.modality === 'SEG') {
+              stackInformation.segmentationType = seriesInformation.segmentationType;
+              stackInformation.segmentationSegments = seriesInformation.segmentationSegments;
+            }
+
+            // parse all frames from file
+            const framesInformation  = [] as any;
+            const framesPixelData  = [] as ArrayBuffer[];
+
+            for (let i = 0; i < seriesInformation.numberOfFrames; i++) {
+                const frameInformation = {} as any;
+                frameInformation.sopInstanceUID = volumeParser.sopInstanceUID(i);
+                frameInformation.url = 'filename not set';
+                frameInformation.index = i;
+                frameInformation.invert = stackInformation.invert;
+                frameInformation.frameTime = volumeParser.frameTime(i);
+                frameInformation.ultrasoundRegions = volumeParser.ultrasoundRegions(i);
+                frameInformation.rows = volumeParser.rows(i);
+                frameInformation.columns = volumeParser.columns(i);
+                frameInformation.numberOfChannels = stackInformation.numberOfChannels;
+                frameInformation.pixelPaddingValue = volumeParser.pixelPaddingValue(i);
+                frameInformation.pixelRepresentation = stackInformation.pixelRepresentation;
+                frameInformation.pixelType = stackInformation.pixelType;
+                frameInformation.pixelSpacing = volumeParser.pixelSpacing(i);
+                frameInformation.spacingBetweenSlices = volumeParser.spacingBetweenSlices(i);
+                frameInformation.sliceThickness = volumeParser.sliceThickness(i);
+                frameInformation.imageOrientation = volumeParser.imageOrientation(i);
+                frameInformation.rightHanded = volumeParser.rightHanded();
+                stackInformation.rightHanded = frameInformation.rightHanded;
+                if (frameInformation.imageOrientation === null) {
+                    frameInformation.imageOrientation = [1, 0, 0, 0, 1, 0];
+                }
+                frameInformation.imagePosition = volumeParser.imagePosition(i);
+                frameInformation.dimensionIndexValues = volumeParser.dimensionIndexValues(i);
+                frameInformation.bitsAllocated = volumeParser.bitsAllocated(i);
+                frameInformation.instanceNumber = volumeParser.instanceNumber(i);
+                frameInformation.windowCenter = volumeParser.windowCenter(i);
+                frameInformation.windowWidth = volumeParser.windowWidth(i);
+                frameInformation.rescaleSlope = volumeParser.rescaleSlope(i);
+                frameInformation.rescaleIntercept = volumeParser.rescaleIntercept(i);
+                // should pass frame index for consistency...
+                const pixelData = volumeParser.extractPixelData(i);
+                frameInformation.minMax = volumeParser.minMaxPixelData(pixelData);
+                frameInformation.byteOffset = 0 + pixelData.byteOffset;
+                frameInformation.byteLength = 0 + pixelData.byteLength;
+
+                // if series.mo
+                if (seriesInformation.modality === 'SEG') {
+                    frameInformation.referencedSegmentNumber = volumeParser.referencedSegmentNumber(i);
+                }
+
+                framesInformation.push(frameInformation);
+                framesPixelData.push(pixelData.buffer);
+            }
+  
+            ctx.postMessage({type: 'parse', framesInformation: JSON.stringify(framesInformation), seriesInformation: JSON.stringify(seriesInformation), stackInformation: JSON.stringify(stackInformation), framesPixelData}, framesPixelData);
+            ctx.postMessage({type: 'parseend'});
+        break;
+        default:
+        break;
+    }
+};
+
+export default {} as typeof Worker & {new (): Worker};

--- a/src/models/models.stack.js
+++ b/src/models/models.stack.js
@@ -6,6 +6,7 @@ import { RGBFormat, RGBAFormat } from 'three/src/constants';
 import CoreColors from '../core/core.colors';
 import CoreUtils from '../core/core.utils';
 import ModelsBase from '../models/models.base';
+import { deflateRawSync } from 'zlib';
 
 const binaryString = require('math-float32-to-binary-string');
 
@@ -471,6 +472,7 @@ export default class ModelsStack extends ModelsBase {
    * Pack current stack pixel data into 8 bits array buffers
    */
   pack() {
+    window.console.log('packing');
     // Get total number of voxels
     const nbVoxels = this._dimensionsIJK.x * this._dimensionsIJK.y * this._dimensionsIJK.z;
 
@@ -567,6 +569,8 @@ export default class ModelsStack extends ModelsBase {
       packed.textureType = RGBAFormat;
       packed.data = data;
     } else if (bitsAllocated === 16 && channels === 1) {
+      window.console.log('go');
+
       let data = new Uint8Array(textureSize * textureSize * 4);
       let coordinate = 0;
       let channelOffset = 0;
@@ -579,6 +583,12 @@ export default class ModelsStack extends ModelsBase {
         if (!Number.isNaN(raw)) {
           data[4 * coordinate + 2 * channelOffset] = raw & 0x00ff;
           data[4 * coordinate + 2 * channelOffset + 1] = (raw >>> 8) & 0x00ff;
+        } else {
+          window.console.log('nan');
+        }
+
+        if (raw > 65000) {
+          window.console.log(raw);
         }
 
         packIndex++;

--- a/src/parsers/parsers.mgh.js
+++ b/src/parsers/parsers.mgh.js
@@ -199,6 +199,20 @@ export default class ParsersMgh extends ParsersVolume {
     }
   }
 
+  pixelRepresentation(frameIndex = 0) {
+    // Return: 0 unsigned, 1 signed
+    switch (this._type) {
+      case ParsersMgh.MRI_UCHAR:
+        return 0;
+      case ParsersMgh.MRI_INT:
+      case ParsersMgh.MRI_SHORT:
+      case ParsersMgh.MRI_FLOAT:
+        return 1;
+      default:
+        throw Error('MGH/MGZ parser: Unknown _type.  _type reports: ' + this._type);
+    }
+  }
+
   bitsAllocated(frameIndex = 0) {
     switch (this._type) {
       case ParsersMgh.MRI_UCHAR:

--- a/src/parsers/parsers.nifti.js
+++ b/src/parsers/parsers.nifti.js
@@ -103,6 +103,44 @@ export default class ParsersNifti extends ParsersVolume {
     return pixelType;
   }
 
+
+  pixelRepresentation(frameIndex = 0) {
+    // papaya.volume.nifti.NIFTI_TYPE_UINT8           = 2;
+    // papaya.volume.nifti.NIFTI_TYPE_INT16           = 4;
+    // papaya.volume.nifti.NIFTI_TYPE_INT32           = 8;
+    // papaya.volume.nifti.NIFTI_TYPE_FLOAT32        = 16;
+    // papaya.volume.nifti.NIFTI_TYPE_COMPLEX64      = 32;
+    // papaya.volume.nifti.NIFTI_TYPE_FLOAT64        = 64;
+    // papaya.volume.nifti.NIFTI_TYPE_RGB24         = 128;
+    // papaya.volume.nifti.NIFTI_TYPE_INT8          = 256;
+    // papaya.volume.nifti.NIFTI_TYPE_UINT16        = 512;
+    // papaya.volume.nifti.NIFTI_TYPE_UINT32        = 768;
+    // papaya.volume.nifti.NIFTI_TYPE_INT64        = 1024;
+    // papaya.volume.nifti.NIFTI_TYPE_UINT64       = 1280;
+    // papaya.volume.nifti.NIFTI_TYPE_FLOAT128     = 1536;
+    // papaya.volume.nifti.NIFTI_TYPE_COMPLEX128   = 1792;
+    // papaya.volume.nifti.NIFTI_TYPE_COMPLEX256   = 2048;
+
+    // 0 unsigned, 1 signed
+
+    let pixelType = 0;
+    if (
+      this._dataSet.datatypeCode === 4 ||
+      this._dataSet.datatypeCode === 16 ||
+      this._dataSet.datatypeCode === 32 ||
+      this._dataSet.datatypeCode === 64 ||
+      this._dataSet.datatypeCode === 128 ||
+      this._dataSet.datatypeCode === 256 ||
+      this._dataSet.datatypeCode === 1024 ||
+      this._dataSet.datatypeCode === 1536 ||
+      this._dataSet.datatypeCode === 1792 ||
+      this._dataSet.datatypeCode === 2048
+    ) {
+      pixelType = 1;
+    }
+    return pixelType;
+  }
+
   bitsAllocated(frameIndex = 0) {
     return this._dataSet.numBitsPerVoxel;
   }
@@ -306,29 +344,29 @@ export default class ParsersNifti extends ParsersVolume {
 
     if (this._orderedData !== null) {
       // just a slice...
-      return this._orderedData.slice(frameOffset, frameOffset + numPixels);
+      return this._orderedData.slice(frameOffset, frameOffset + numPixels).slice();
     } else if (this._dataSet.datatypeCode === 2) {
       // unsigned int 8 bit
-      return new Uint8Array(buffer, frameOffset, numPixels);
+      return new Uint8Array(buffer, frameOffset, numPixels).slice();
     } else if (this._dataSet.datatypeCode === 256) {
       // signed int 8 bit
-      return new Int8Array(buffer, frameOffset, numPixels);
+      return new Int8Array(buffer, frameOffset, numPixels).slice();
     } else if (this._dataSet.datatypeCode === 512) {
       // unsigned int 16 bit
       frameOffset = frameOffset * 2;
-      return new Uint16Array(buffer, frameOffset, numPixels);
+      return new Uint16Array(buffer, frameOffset, numPixels).slice();
     } else if (this._dataSet.datatypeCode === 4) {
       // signed int 16 bit
       frameOffset = frameOffset * 2;
-      return new Int16Array(buffer, frameOffset, numPixels);
+      return new Int16Array(buffer, frameOffset, numPixels).slice();
     } else if (this._dataSet.datatypeCode === 8) {
       // signed int 32 bit
       frameOffset = frameOffset * 4;
-      return new Int32Array(buffer, frameOffset, numPixels);
+      return new Int32Array(buffer, frameOffset, numPixels).slice();
     } else if (this._dataSet.datatypeCode === 16) {
       // signed float 32 bit
       frameOffset = frameOffset * 4;
-      const data = new Float32Array(buffer, frameOffset, numPixels);
+      const data = new Float32Array(buffer, frameOffset, numPixels).slice();
       for (let i = 0; i < data.length; i++) {
         if (data[i] === Infinity || data[i] === -Infinity) {
           data[i] = 0;

--- a/src/parsers/parsers.nrrd.js
+++ b/src/parsers/parsers.nrrd.js
@@ -130,6 +130,23 @@ export default class ParsersNifti extends ParsersVolume {
     return pixelType;
   }
 
+  pixelRepresentation(frameIndex = 0) {
+    let pixelRepresentation = 0;
+
+    if (
+      this._dataSet.type === 'int8' ||
+      this._dataSet.type === 'char' ||
+      this._dataSet.type === 'int16' ||
+      this._dataSet.type === 'short' ||
+      this._dataSet.type === 'int32' ||
+      this._dataSet.type === 'float'
+    ) {
+      pixelRepresentation = 1;
+    }
+
+    return pixelRepresentation;
+  }
+
   /**
    * Bits allocated
    *

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "target": "ES2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "declaration": false /* Generates corresponding '.d.ts' file. */,
     "declarationMap": false /* Generates a sourcemap for each corresponding '.d.ts' file. */,
     "sourceMap": true /* Generates corresponding '.map' file. */,
     "outDir": "./build" /* Redirect output structure to the directory. */,
     "strict": false /* Enable all strict type-checking options. */,
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    "lib": ["es7", "dom"],  // allow latest features such as array.includes(...)
   },
   "include": [
     "./src/**/*.ts",

--- a/webpack.config.build.js
+++ b/webpack.config.build.js
@@ -15,18 +15,26 @@ const config = {
     library: 'AMI',
     libraryTarget: 'umd',
     umdNamedDefine: true,
+    globalObject: "this",
   },
   mode,
   resolve: {
     modules: [path.resolve(__dirname, 'src'), 'node_modules'],
     extensions: ['.ts', '.js', '.css', '.html'],
     alias: {
-      base: path.resolve(__dirname, 'src'),
+      examplesBase: path.resolve(__dirname, 'src'),
       pako: path.resolve(__dirname, 'node_modules', 'pako'),
     },
   },
   module: {
     rules: [
+      {
+        test: /\.worker\.ts$/,
+        use: {
+          loader: 'worker-loader',
+          // options: { inline: true, fallback: false } ,
+        }
+      },
       {
         test: /\.js$/,
         loader: 'babel-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7062,7 +7062,7 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-schema-utils@^0.4.4, schema-utils@^0.4.5:
+schema-utils@^0.4.0, schema-utils@^0.4.4, schema-utils@^0.4.5:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
   integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
@@ -8739,6 +8739,14 @@ worker-farm@^1.5.2:
   integrity sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==
   dependencies:
     errno "~0.1.7"
+
+worker-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
+  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
+  dependencies:
+    loader-utils "^1.0.0"
+    schema-utils "^0.4.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
* Use web workers to see if loading performance can be improved.
* Get rid of Progress Bar in loader.

Findings:
* One worker per DICOM file is not a good solution since it takes about 10ms to instance a worker, it ends up being significantly slower.

Next step:
* Use a pool of workers (4?) to load the data. Those workers will only be initialized 1 time (costs about 40ms) however that should then allow us to divide parsing time in 4.