### PR TITLE
remove webpack-watch-livereload-plugin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,8 +129,7 @@
     "webpack": "^4.16.3",
     "webpack-bundle-analyzer": "^2.9.0",
     "webpack-cli": "^3.1.0",
-    "webpack-dev-server": "^3.1.5",
-    "webpack-watch-livereload-plugin": "^0.0.1"
+    "webpack-dev-server": "^3.1.5"
   },
   "engines": {
     "node": ">=6.9.0"


### PR DESCRIPTION
This package is at version `0.0.1`, it breaks `yarn install` of `ami` with node v10 (probably also on 12); because of a node-gyp build error of outdated `utf-8-validate`.

```
yarn why utf-8-validate
yarn why v1.13.0
[1/4] Why do we have the module "utf-8-validate"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "utf-8-validate@1.2.2"
info Reasons this module exists
   - "_project_#ami.js#webpack-watch-livereload-plugin#livereload#ws" depends on it
   - Hoisted from "_project_#ami.js#webpack-watch-livereload-plugin#livereload#ws#utf-8-validate"
```