### PR TITLE
Do not mutate referenceArray within mergeModels

### DIFF
--- a/src/models/models.base.js
+++ b/src/models/models.base.js
@@ -32,7 +32,7 @@ export default class ModelsBase {
         } else if (j === referenceArray.length - 1) {
           // last merge was not successful
           // this is a new targetArray
-          referenceArray.push(targetArray[i]);
+          referenceArray = [...referenceArray, targetArray[i]];
         }
       }
     }


### PR DESCRIPTION
Prevent referenceArray from mutating and return new one instead. When we use mergeSeries function it mutated seriesContainer. Now it more pure. No need to create deep copy of seriesContainer before mergeSeries if there is need to use it few times.